### PR TITLE
Adding git attribute file to prevent EOL to be converted to CRLF on Win32

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
Because CRLF mess with "gulp build".
See :
https://stackoverflow.com/questions/2517190/how-do-i-force-git-to-use-lf-instead-of-crlf-under-windows