### PR TITLE
Improved error and docs verbiage

### DIFF
--- a/packages/amplify-cli-auth/src/commands/login.js
+++ b/packages/amplify-cli-auth/src/commands/login.js
@@ -21,7 +21,7 @@ export default {
 		if (argv.hasOwnProperty('username')) {
 			const questions = [];
 
-			if (!argv.username) {
+			if (!argv.username || typeof argv.username !== 'string') {
 				questions.push({
 					type: 'input',
 					name: 'username',
@@ -32,7 +32,7 @@ export default {
 				});
 			}
 
-			if (!argv.password) {
+			if (!argv.password || typeof argv.password !== 'string') {
 				questions.push({
 					type: 'password',
 					name: 'password',

--- a/packages/amplify-cli-utils/src/auth.js
+++ b/packages/amplify-cli-utils/src/auth.js
@@ -15,7 +15,8 @@ export function createAuth(params) {
 		return new Auth(params);
 	} catch (err) {
 		if (err.code === 'ERR_SECURE_STORE_UNAVAILABLE') {
-			err.message = 'Secure token store is not available.\nPlease reinstall the AMPLIFY CLI by running:\n    npm i -g --unsafe-perm @axway/amplify-cli';
+			const isWin = process.platform = 'win32';
+			err.message = `Secure token store is not available.\nPlease reinstall the AMPLIFY CLI by running:\n    ${isWin ? '' : 'sudo '}npm i -g ${isWin ? '' : '--unsafe-perm '}@axway/amplify-cli`;
 		}
 		throw err;
 	}

--- a/packages/amplify-cli-utils/src/auth.js
+++ b/packages/amplify-cli-utils/src/auth.js
@@ -16,7 +16,7 @@ export function createAuth(params) {
 	} catch (err) {
 		if (err.code === 'ERR_SECURE_STORE_UNAVAILABLE') {
 			const isWin = process.platform = 'win32';
-			err.message = `Secure token store is not available.\nPlease reinstall the AMPLIFY CLI by running:\n    ${isWin ? '' : 'sudo '}npm i -g ${isWin ? '' : '--unsafe-perm '}@axway/amplify-cli`;
+			err.message = `Secure token store is not available.\nPlease reinstall the AMPLIFY CLI by running:\n    ${isWin ? '' : 'sudo '}npm install --global ${isWin ? '' : '--unsafe-perm '}@axway/amplify-cli`;
 		}
 		throw err;
 	}

--- a/packages/amplify-cli/README.md
+++ b/packages/amplify-cli/README.md
@@ -8,10 +8,15 @@ The AMPLIFY CLI requires [Node.js][1] 8.10.0 or newer.
 
 ## Installation
 
-	npm i -g --unsafe-perm @axway/amplify-cli
+	npm install --global @axway/amplify-cli
 
-> Note: we recommend the `--unsafe-perm` flag to avoid file permission issues when `npm` installs
-> the `keytar` package.
+### macOS and Linux Users
+
+When installing the AMPLIFY CLI globally, you may need to prefix the command above with `sudo`.
+When using `sudo`, you will also need to specify the `--unsafe-perm` flag to avoid issues when
+installing the `keytar` package.
+
+	sudo npm install --global --unsafe-perm @axway/amplify-cli
 
 ## Quick Start
 


### PR DESCRIPTION
fix(amplify-cli-auth): Fixed bug with username not being prompted for.
fix(amplify-cli-utils): Improved error message when keytar fails to load.
doc(amplify-cli): Improved install docs in readme.