### PR TITLE
fix(cli-auth): Pass account name directly into getAccounts() instead …

### DIFF
--- a/packages/amplify-cli-auth/LICENSE
+++ b/packages/amplify-cli-auth/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018-2019 by Axway, Inc.
+Copyright 2018-2020 by Axway, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/amplify-cli-auth/src/commands/whoami.js
+++ b/packages/amplify-cli-auth/src/commands/whoami.js
@@ -19,7 +19,7 @@ export default {
 		const client = auth.createAuth(params);
 
 		if (argv.accountName) {
-			const account = await client.getAccount({ accountName: argv.accountName });
+			const account = await client.getAccount(argv.accountName);
 			if (account) {
 				console.log(JSON.stringify(account, null, '  '));
 			} else {


### PR DESCRIPTION
fix(cli-auth): Pass account name directly into getAccounts() instead of as auth params. Fixes CLI-82.

https://techweb.axway.com/jira/browse/CLI-82