### PR TITLE
Auth SDK env handling

### DIFF
--- a/docs/Release Notes/AMPLIFY CLI 2.0.0.md
+++ b/docs/Release Notes/AMPLIFY CLI 2.0.0.md
@@ -86,6 +86,9 @@ npm i -g @axway/amplify-cli@2.0.0
 
 ### amplify-auth-sdk@2.1.3
 
+ * fix: Copy options object so the original reference isn't modified.
+ * fix: `env` in the account object was the resolved environment settings including URLs instead of
+   just the environment name.
  * chore: Updated dependencies.
 
 ### amplify-cli-auth@2.0.0

--- a/packages/amplify-auth-sdk/CHANGELOG.md
+++ b/packages/amplify-auth-sdk/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v2.1.3
 
+ * fix: Copy options object so the original reference isn't modified.
+ * fix: `env` in the account object was the resolved environment settings including URLs instead of
+   just the environment name.
  * chore: Updated dependencies.
 
 # v2.1.2 (Jul 2, 2020)

--- a/packages/amplify-auth-sdk/src/authenticators/authenticator.js
+++ b/packages/amplify-auth-sdk/src/authenticators/authenticator.js
@@ -463,7 +463,7 @@ export default class Authenticator {
 				authenticator: this.constructor.name,
 				baseUrl:       this.baseUrl,
 				clientId:      this.clientId,
-				env:           this.env,
+				env:           this.env.name,
 				expires: {
 					access: (tokens.expires_in * 1000) + now,
 					refresh: (tokens.refresh_expires_in * 1000) + now


### PR DESCRIPTION
fix(auth-sdk): Copy options object so the original reference isn't modified.
fix(auth-sdk): 'env' in the account object was the resolved environment settings including URLs instead of just the environment name.