### PR TITLE
AMPLIFY CLI config directory migration

### DIFF
--- a/integration-tests/utils.js
+++ b/integration-tests/utils.js
@@ -5,7 +5,7 @@ const { run } = require('appcd-subprocess');
 const isWindows = process.platform === 'win32';
 
 const axwayHome = join(homedir(), '.axway');
-const configFile = join(axwayHome, 'amplify-cli.json');
+const configFile = join(axwayHome, 'amplify-cli', 'amplify-cli.json');
 let amplifyCmd;
 
 function preCheck() {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp-debug": "^4.0.0",
     "gulp-plumber": "^1.2.1",
     "lerna": "^3.22.1",
-    "mocha": "^8.0.1",
+    "mocha": "^8.1.1",
     "pretty-log": "^0.1.0",
     "semver": "^7.3.2",
     "tar-stream": "^2.1.3"

--- a/packages/amplify-auth-sdk/CHANGELOG.md
+++ b/packages/amplify-auth-sdk/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.2.0
+
+ * refactor(secure-store): Moved keytar file from `~/.axway/lib` to `~/.axway/amplify-cli/lib`.
+ * refactor(file-store): Moved token store file from `~/.axway` to `~/.axway/amplify-cli`.
+ * chore: Updated dependencies.
+
 # v2.1.3 (Jul 24, 2020)
 
  * fix: Added token store backwards compatibility by writing both a v2 and v1 versions of the token

--- a/packages/amplify-auth-sdk/package.json
+++ b/packages/amplify-auth-sdk/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "accepts": "^1.3.7",
+    "appcd-fs": "^2.0.0",
     "cross-spawn": "^7.0.3",
     "fs-extra": "^9.0.1",
     "got": "^11.5.1",
@@ -29,7 +30,7 @@
     "snooplogg": "^3.0.0",
     "source-map-support": "^0.5.19",
     "tmp": "^0.2.1",
-    "uuid": "^8.2.0"
+    "uuid": "^8.3.0"
   },
   "devDependencies": {
     "appcd-gulp": "^3.0.1",

--- a/packages/amplify-auth-sdk/src/stores/secure-store.js
+++ b/packages/amplify-auth-sdk/src/stores/secure-store.js
@@ -7,7 +7,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import snooplogg from 'snooplogg';
 import tmp from 'tmp';
-
+import { isDir, isFile } from 'appcd-fs';
 import { sync as spawnSync } from 'cross-spawn';
 
 const { log, warn } = snooplogg('amplify-auth:secure-store');
@@ -43,8 +43,15 @@ export default class SecureStore extends FileStore {
 			throw E.INVALID_PARAMETER('Secure store requires the home directory to be specified');
 		}
 
+		const libDir = path.join(homeDir, 'amplify-cli', 'lib');
+		const legacyLibDir = path.join(homeDir, 'lib');
+
+		if (!isDir(libDir) && isDir(legacyLibDir)) {
+			fs.moveSync(legacyLibDir, libDir);
+		}
+
 		const keytarVersion = fs.readJsonSync(path.resolve(__dirname, '..', '..', 'package.json')).keytar.replace(/[^\d.]*/g, '');
-		const prefix = path.join(homeDir, 'lib', 'keytar', `${keytarVersion}_${process.platform}_${process.arch}_${process.versions.modules}`);
+		const prefix = path.join(libDir, 'keytar', `${keytarVersion}_${process.platform}_${process.arch}_${process.versions.modules}`);
 		const keytarPath = path.join(prefix, 'node_modules', 'keytar');
 		let keytar;
 
@@ -114,6 +121,12 @@ export default class SecureStore extends FileStore {
 		this.keytar = keytar;
 		this.serviceName = opts.secureServiceName || 'Axway AMPLIFY Auth';
 		this.tokenStoreFile = path.join(this.tokenStoreDir, this.filename);
+
+		// check if token store file needs to be migrated
+		const legacyTokenStoreFile = path.join(homeDir, this.filename);
+		if (!isFile(this.tokenStoreFile) && isFile(legacyTokenStoreFile)) {
+			fs.moveSync(legacyTokenStoreFile, this.tokenStoreFile);
+		}
 	}
 
 	/**

--- a/packages/amplify-auth-sdk/test/test-token-store.js
+++ b/packages/amplify-auth-sdk/test/test-token-store.js
@@ -218,7 +218,7 @@ describe('Token Store', () => {
 					realm:          'test_realm',
 					tokenStoreType: 'file'
 				});
-			}).to.throw(TypeError, 'Token store requires a token store path');
+			}).to.throw(TypeError, 'Token store requires a home directory');
 		});
 
 		it('should persist the token to a file', async function () {

--- a/packages/amplify-cli-auth/CHANGELOG.md
+++ b/packages/amplify-cli-auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.1.0
+
+ * style: Adopted Axway style guide for tables.
+ * chore: Updated dependencies.
+
 # v2.0.3 (Aug 3, 2020)
 
  * fix: Fixed bug in `switch` command which was using the org name instead of the org id.

--- a/packages/amplify-cli-auth/package.json
+++ b/packages/amplify-cli-auth/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@axway/amplify-cli-utils": "^3.0.6",
-    "cli-kit": "^1.5.1",
+    "cli-kit": "^1.6.1",
     "enquirer": "^2.3.6",
     "pretty-ms": "^7.0.0",
     "snooplogg": "^3.0.0",

--- a/packages/amplify-cli-auth/src/commands/list.js
+++ b/packages/amplify-cli-auth/src/commands/list.js
@@ -38,7 +38,7 @@ export default {
 		}
 
 		const { green } = snooplogg.styles;
-		const table = createTable('Account Name', 'Organization', 'Expires', 'Environment');
+		const table = createTable([ 'Account Name', 'Organization', 'Expires', 'Environment' ]);
 		const now = Date.now();
 		const pretty = require('pretty-ms');
 		const urlRE = /^.*\/\//;

--- a/packages/amplify-cli-pm/CHANGELOG.md
+++ b/packages/amplify-cli-pm/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.1.0
+
+ * style: Adopted Axway style guide for tables.
+ * chore: Updated dependencies.
+
 # v2.0.2 (Jul 24, 2020)
 
  * chore: Updated dependencies.

--- a/packages/amplify-cli-pm/package.json
+++ b/packages/amplify-cli-pm/package.json
@@ -28,7 +28,7 @@
     "@axway/amplify-cli-utils": "^3.0.6",
     "@axway/amplify-config": "^2.0.3",
     "@axway/amplify-registry-sdk": "^2.0.2",
-    "cli-kit": "^1.5.1",
+    "cli-kit": "^1.6.1",
     "listr": "^0.14.3",
     "npm-package-arg": "^8.0.1",
     "ora": "4.0.5",

--- a/packages/amplify-cli-pm/src/commands/list.js
+++ b/packages/amplify-cli-pm/src/commands/list.js
@@ -32,7 +32,7 @@ export default {
 			return;
 		}
 
-		const table = createTable('Name', 'Versions');
+		const table = createTable([ 'Name', 'Versions' ]);
 		const unmanaged = {};
 
 		for (const pkg of installed) {

--- a/packages/amplify-cli-pm/src/commands/search.js
+++ b/packages/amplify-cli-pm/src/commands/search.js
@@ -57,7 +57,7 @@ export default {
 			return;
 		}
 
-		const table = createTable('Name', 'Versions', 'Type', 'Description');
+		const table = createTable([ 'Name', 'Versions', 'Type', 'Description' ]);
 
 		for (const pkg of results) {
 			table.push([

--- a/packages/amplify-cli-utils/CHANGELOG.md
+++ b/packages/amplify-cli-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.1.0
+
+ * refactor: Moved AMPLIFY CLI config file from `~/.axway` to `~/.axway/amplify-cli`.
+
 # v3.0.6 (Jul 24, 2020)
 
  * chore: Updated dependencies.

--- a/packages/amplify-cli-utils/src/index.js
+++ b/packages/amplify-cli-utils/src/index.js
@@ -63,20 +63,21 @@ export function buildParams(opts = {}, config) {
 /**
  * Creates a table with default styles and padding.
  *
- * @param {...String} head - One or more headings.
+ * @param {Array.<String>} head - One or more headings.
+ * @param {Number} [indent] - The number of spaces to indent the table.
  * @returns {Table}
  */
-export function createTable(...head) {
+export function createTable(head, indent = 0) {
 	const Table = require('cli-table3');
 	return new Table({
 		chars: {
 			bottom: '', 'bottom-left': '', 'bottom-mid': '', 'bottom-right': '',
-			left: '', 'left-mid': '',
+			left: ' '.repeat(indent), 'left-mid': '',
 			mid: '', 'mid-mid': '', middle: '  ',
 			right: '', 'right-mid': '',
 			top: '', 'top-left': '', 'top-mid': '', 'top-right': ''
 		},
-		head,
+		head: Array.isArray(head) ? head.map(s => String(s).toUpperCase()) : head,
 		style: {
 			head: [ 'bold' ],
 			'padding-left': 0,

--- a/packages/amplify-cli-utils/src/locations.js
+++ b/packages/amplify-cli-utils/src/locations.js
@@ -5,4 +5,4 @@ import path from 'path';
 export const axwayHome = path.join(os.homedir(), '.axway');
 
 // Files
-export const configFile = path.join(axwayHome, 'amplify-cli.json');
+export const configFile = path.join(axwayHome, 'amplify-cli', 'amplify-cli.json');

--- a/packages/amplify-cli-utils/test/test-config.js
+++ b/packages/amplify-cli-utils/test/test-config.js
@@ -37,17 +37,15 @@ describe('config', () => {
 		done();
 	});
 
-	it('should default to loading amplify config', done => {
+	it('should default to loading amplify config', () => {
 		fs.copySync(path.join(fixturesDir, 'existing-file.json'), configFile, { overwrite: true });
 		const cfg = loadConfig();
 		expect(cfg.data(Config.Base)).to.deep.equal({ existing: true });
-		done();
 	});
 
-	it('should allow a custom userConfig to be passed in', done => {
+	it('should allow a custom userConfig to be passed in', () => {
 		const configFile = path.join(fixturesDir, 'my-own-config.json');
 		const cfg = loadConfig({ configFile });
 		expect(cfg.data(Config.Base)).to.deep.equal({ ownConfig: true });
-		done();
 	});
 });

--- a/packages/amplify-cli/CHANGELOG.md
+++ b/packages/amplify-cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v2.0.0-rc3 (Jul 24, 2020)
+# v2.0.0
 
  * BREAKING CHANGE: Dropped support for Node.js 10.12.0 and older.
    ([CLI-89](https://jira.axway.com/browse/CLI-89))

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -24,9 +24,9 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@axway/amplify-cli-auth": "^2.0.2",
+    "@axway/amplify-cli-auth": "^2.0.3",
     "@axway/amplify-cli-pm": "^2.0.2",
-    "cli-kit": "1.5.1",
+    "cli-kit": "1.6.1",
     "source-map-support": "^0.5.19",
     "v8-compile-cache": "^2.1.1"
   },

--- a/packages/amplify-config/CHANGELOG.md
+++ b/packages/amplify-config/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.1.0
+
+ * refactor: Moved AMPLIFY CLI config file from `~/.axway` to `~/.axway/amplify-cli`.
+ * chore: Updated dependencies.
+
 # v2.0.3 (Jul 24, 2020)
 
  * chore: Updated dependencies.

--- a/packages/amplify-config/package.json
+++ b/packages/amplify-config/package.json
@@ -24,6 +24,7 @@
     "test": "gulp test"
   },
   "dependencies": {
+    "appcd-fs": "^2.0.0",
     "appcd-path": "^2.0.1",
     "config-kit": "^1.2.1",
     "fs-extra": "^9.0.1",

--- a/packages/amplify-config/src/index.js
+++ b/packages/amplify-config/src/index.js
@@ -4,12 +4,15 @@ if (!Error.prepareStackTrace) {
 }
 
 import Config from 'config-kit';
+import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
-
 import { expandPath } from 'appcd-path';
+import { isFile } from 'appcd-fs';
 
-export const configFile = path.join(os.homedir(), '.axway', 'amplify-cli.json');
+const axwayHome = path.join(os.homedir(), '.axway');
+
+export const configFile = path.join(axwayHome, 'amplify-cli', 'amplify-cli.json');
 
 /**
  * Load a users config, if no userConfig is given then the default AMPLIFY CLI config will be
@@ -29,6 +32,13 @@ export function loadConfig(opts = {}) {
 
 	if (opts.configFile && typeof opts.configFile !== 'string') {
 		throw new TypeError('Expected config file to be a string');
+	}
+
+	// in v2.1.0, the config file was moved to keep the ~/.axway directory tidy as other Axway
+	// CLI's are added
+	const legacyConfigFile = path.join(axwayHome, 'amplify-cli.json');
+	if (!isFile(configFile) && isFile(legacyConfigFile)) {
+		fs.moveSync(legacyConfigFile, configFile);
 	}
 
 	const cfg = new Config({

--- a/packages/amplify-registry-sdk/CHANGELOG.md
+++ b/packages/amplify-registry-sdk/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.1.0
+
+ * refactor: Moved cache and packages directories from `~/.axway` to `~/.axway/amplify-cli`.
+
 # v2.0.2 (Jul 24, 2020)
 
  * chore: Updated dependencies.

--- a/packages/amplify-registry-sdk/src/installers/common.js
+++ b/packages/amplify-registry-sdk/src/installers/common.js
@@ -1,14 +1,29 @@
 import fs from 'fs-extra';
 import loadConfig from '@axway/amplify-config';
-
 import { extract } from 'tar';
 import { isDir, isFile } from 'appcd-fs';
 import { join } from 'path';
 import { locations } from '@axway/amplify-cli-utils';
 import { run, which } from 'appcd-subprocess';
 
-export const cacheDir = join(locations.axwayHome, 'cache');
-export const packagesDir = join(locations.axwayHome, 'packages');
+export const cacheDir = join(locations.axwayHome, 'amplify-cli', 'cache');
+export const packagesDir = join(locations.axwayHome, 'amplify-cli', 'packages');
+
+/**
+ * Migrate the cache and packages directories from the old to the new location.
+ */
+{
+	const legacyCacheDir = join(locations.axwayHome, 'cache');
+	const legacyPackagesDir = join(locations.axwayHome, 'packages');
+
+	if (!isDir(cacheDir) && isDir(legacyCacheDir)) {
+		fs.moveSync(legacyCacheDir, cacheDir);
+	}
+
+	if (!isDir(packagesDir) && isDir(legacyPackagesDir)) {
+		fs.moveSync(legacyPackagesDir, packagesDir);
+	}
+}
 
 const scopedPackageRegex = /@[a-z0-9][\w-.]+\/?/;
 

--- a/packages/amplify-registry-sdk/src/installers/fetchers.js
+++ b/packages/amplify-registry-sdk/src/installers/fetchers.js
@@ -5,8 +5,6 @@ import { download } from 'targit';
 import { existsSync } from 'fs';
 import { join } from 'path';
 
-const npmCacheDir = join(cacheDir, 'npm');
-
 export default async function fetchPackage(pkgInfo) {
 	let downloadLocation;
 
@@ -29,7 +27,7 @@ export default async function fetchPackage(pkgInfo) {
 				version = pkg.version;
 			}
 
-			downloadLocation = join(npmCacheDir, name, version, 'package.tgz');
+			downloadLocation = join(cacheDir, 'npm', name, version, 'package.tgz');
 
 			if (!existsSync(downloadLocation)) {
 				await pacote.tarball.file(`${name}@${version}`, downloadLocation, opts);


### PR DESCRIPTION
refactor(auth-sdk:secure-store): Moved keytar file from `~/.axway/lib` to `~/.axway/amplify-cli/lib`.
refactor(auth-sdk:file-store): Moved token store file from `~/.axway` to `~/.axway/amplify-cli`.
refactor(cli-utils,config): Moved AMPLIFY CLI config file from`'~/.axway` to `~/.axway/amplify-cli`.
refactor(registry-sdk): Moved cache and packages directories from `~/.axway` to `~/.axway/amplify-cli`.
style: Adopted Axway style guide for tables.
chore: Updated dependencies.