### PR TITLE
Minor bug fixes

### DIFF
--- a/packages/amplify-auth-sdk/CHANGELOG.md
+++ b/packages/amplify-auth-sdk/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.3.3
+
+ * fix(login): Handle stale access tokens when finding an account by removing the now invalid
+   token.
+ * fix(login): Fixed bug where invalid accounts were not being removed from the token store.
+ * fix(switch): Validate account before initiating the org switch.
+
 # v2.3.2 (Nov 10, 2020)
 
  * fix: Downgraded `keytar` from 7.0.0 to 6.0.1 due to botched `keytar` release.

--- a/packages/amplify-cli-auth/CHANGELOG.md
+++ b/packages/amplify-cli-auth/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.2.5
+
+ * fix(login): Fixed logged in message after logging in using a service account which has no
+   platform organization.
+ * fix(login): Load session after manually logging in.
+
 # v2.2.4 (Nov 12, 2020)
 
  * chore: Updated dependencies.

--- a/packages/amplify-cli-auth/package.json
+++ b/packages/amplify-cli-auth/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@axway/amplify-cli-utils": "^4.1.2",
-    "cli-kit": "^1.8.5",
+    "cli-kit": "^1.8.6",
     "enquirer": "^2.3.6",
     "pretty-ms": "^7.0.1",
     "snooplogg": "^3.0.0",

--- a/packages/amplify-cli-auth/src/commands/login.js
+++ b/packages/amplify-cli-auth/src/commands/login.js
@@ -82,8 +82,8 @@ export default {
 
 			process.on('SIGINT', () => cancel());
 
-			console.log(`Please open following link in your browser:\n\n  ${url}\n`);
-			account = await promise;
+			console.log(`Please open following link in your browser:\n\n  ${highlight(url)}\n`);
+			account = await sdk.auth.loadSession(await promise);
 		} else {
 			try {
 				account = await sdk.auth.login({ force: argv.force });
@@ -123,7 +123,11 @@ export default {
 			return;
 		}
 
-		console.log(`You are logged into ${highlight(account.org.name)} as ${highlight(account.user.email || account.name)}.\n`);
+		if (account.org?.name) {
+			console.log(`You are logged into ${highlight(account.org.name)} as ${highlight(account.user.email || account.name)}.\n`);
+		} else {
+			console.log(`You are logged as ${highlight(account.user.email || account.name)}.\n`);
+		}
 
 		// set the current
 		if (accounts.length === 1) {

--- a/packages/amplify-cli-pm/package.json
+++ b/packages/amplify-cli-pm/package.json
@@ -27,7 +27,7 @@
     "@axway/amplify-cli-utils": "^4.1.2",
     "@axway/amplify-config": "^3.0.3",
     "@axway/amplify-registry-sdk": "^2.2.4",
-    "cli-kit": "^1.8.5",
+    "cli-kit": "^1.8.6",
     "listr": "^0.14.3",
     "npm-package-arg": "^8.1.0",
     "ora": "^5.1.0",

--- a/packages/amplify-cli-utils/package.json
+++ b/packages/amplify-cli-utils/package.json
@@ -28,7 +28,7 @@
     "appcd-fs": "^2.0.0",
     "boxen": "^4.2.0",
     "check-kit": "^1.0.1",
-    "cli-kit": "^1.8.5",
+    "cli-kit": "^1.8.6",
     "cli-table3": "^0.6.0",
     "fs-extra": "^9.0.1",
     "snooplogg": "^3.0.0",

--- a/packages/amplify-registry-sdk/CHANGELOG.md
+++ b/packages/amplify-registry-sdk/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.2.5
+
+ * fix: Check correct status code to determine if package is found.
+
 # v2.2.4 (Nov 12, 2020)
 
  * chore: Updated dependencies.

--- a/packages/amplify-registry-sdk/src/registry.js
+++ b/packages/amplify-registry-sdk/src/registry.js
@@ -72,13 +72,12 @@ export default class Registry {
 			const data = await got(url, { headers, responseType: 'json' });
 			body = data.body;
 		} catch (err) {
-			if (err.statusCode === 404) {
+			if (err.response?.statusCode === 404) {
 				const error = new Error(`No version data for ${name}@${version}`);
 				error.code = 'ENOVERSIONDATA';
 				throw error;
-			} else {
-				throw err;
 			}
+			throw err;
 		}
 
 		const result = body.result;

--- a/packages/amplify-registry-sdk/test/test-common.js
+++ b/packages/amplify-registry-sdk/test/test-common.js
@@ -219,13 +219,14 @@ describe('common utils', () => {
 			await npmInstall({ directory: join(fixturesDir, 'common', 'npm-install-dir'), npm: 'npm' });
 		});
 
-		it('should error if npm install fails', function () {
+		it('should error if npm install fails', async function () {
 			this.timeout(25000);
 			setTimeout(() => {
 				this.fakeChild.stdout.emit('data', '');
 				this.fakeChild.emit('close', 1);
 			}, 1000);
-			return expect(npmInstall({ directory: join(fixturesDir, 'common', 'npm-install-dir'), npm: 'npm' })).to.be.rejectedWith(Error, 'Subprocess exited with code 1');
+			await expect(npmInstall({ directory: join(fixturesDir, 'common', 'npm-install-dir'), npm: 'npm' }))
+				.to.be.rejectedWith(Error, /^Failed to npm install/);
 		});
 
 		it('should attempt to find npm if no npm executable is passed in', async function () {

--- a/packages/amplify-sdk/CHANGELOG.md
+++ b/packages/amplify-sdk/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.5.2
+
+ * fix(auth): Don't load account session when doing a manual login.
+
 # v1.5.1 (Nov 10, 2020)
 
  * chore: Updated dependencies.

--- a/packages/amplify-sdk/src/index.js
+++ b/packages/amplify-sdk/src/index.js
@@ -161,6 +161,12 @@ export class AmplifySDK {
 				}
 
 				account = await this.client.login(opts);
+
+				if (opts.manual) {
+					// account is actually an object containing `cancel`, `promise`, and `url`
+					return account;
+				}
+
 				return await this.auth.loadSession(account);
 			},
 

--- a/packages/axway-cli/package.json
+++ b/packages/axway-cli/package.json
@@ -30,7 +30,7 @@
     "@axway/amplify-cli-auth": "^2.2.4",
     "@axway/amplify-cli-pm": "^2.2.5",
     "@axway/amplify-cli-utils": "^4.1.2",
-    "cli-kit": "^1.8.5",
+    "cli-kit": "^1.8.6",
     "source-map-support": "^0.5.19",
     "v8-compile-cache": "^2.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,9 +2746,9 @@ balanced-match@^1.0.0:
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.3.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.0.tgz#2d03045876d9e2b68a7a0f87d6bd163595e3b6af"
-  integrity sha512-Jrdy04F2EKcNggUDfubMUPNAZg2vMquLQSm8sKLYJvz40ClFL1S8GKyDshGkNsbNNE5Z+fQavzU7nSK1I9JUGA==
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 base@^0.11.1:
   version "0.11.2"
@@ -2829,7 +2829,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
-bn.js@^5.1.1:
+bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
@@ -2933,11 +2933,11 @@ browserify-des@^1.0.0:
     safe-buffer "^5.1.2"
 
 browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
-  integrity sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.1.0.tgz#b2fd06b5b75ae297f7ce2dc651f918f5be158c8d"
+  integrity sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==
   dependencies:
-    bn.js "^4.1.0"
+    bn.js "^5.0.0"
     randombytes "^2.0.1"
 
 browserify-sign@^4.0.0:
@@ -3473,42 +3473,6 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-kit@0.16.2:
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/cli-kit/-/cli-kit-0.16.2.tgz#c6b9b1ae113128443bc24a0d3a6dd8d016e9ebad"
-  integrity sha512-qhYSZ70fbmme5mF5IajxhJESq5QFSOANyhahTI1Hu8TLTyGqWlshyrXO7/8TQ9U/7ypvZ/WjdmSWoBOKVuqJHQ==
-  dependencies:
-    argv-split "^2.0.1"
-    fast-levenshtein "^2.0.6"
-    fs-extra "^8.1.0"
-    hook-emitter "^4.0.2"
-    lodash.camelcase "^4.3.0"
-    pkg-dir "^4.2.0"
-    pluralize "^8.0.0"
-    semver "^7.3.0"
-    snooplogg "^2.3.3"
-    source-map-support "^0.5.16"
-    which "^2.0.2"
-    ws "^7.2.3"
-
-cli-kit@1.8.5, cli-kit@^1.8.5:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/cli-kit/-/cli-kit-1.8.5.tgz#d12936f25f9048b6ecacb284f60d13ae244741f8"
-  integrity sha512-8BmN+U8Z8wefz5ffqxmdPulSB+G6UV/6l3Hhw6ZH3bKkKzSHKT2n+QZiZ/0UG/yhBoJcOXBOBTKw2UlSoGMCMA==
-  dependencies:
-    argv-split "^2.0.1"
-    fastest-levenshtein "^1.0.12"
-    fs-extra "^9.0.1"
-    hook-emitter "^4.1.0"
-    lodash.camelcase "^4.3.0"
-    pkg-dir "^5.0.0"
-    pluralize "^8.0.0"
-    semver "^7.3.2"
-    snooplogg "^3.0.0"
-    source-map-support "^0.5.19"
-    which "^2.0.2"
-    ws "^7.4.0"
-
 cli-kit@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/cli-kit/-/cli-kit-0.12.0.tgz#2ba0d7b49e5745f980c2513e81261ca3b9eebb1b"
@@ -3525,6 +3489,24 @@ cli-kit@^0.12.0:
     snooplogg "^2.1.0"
     source-map-support "^0.5.13"
     which "^1.3.1"
+
+cli-kit@^1.8.6:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/cli-kit/-/cli-kit-1.8.6.tgz#c4bc7008335d05ec215f720fbfad9702ead0c77e"
+  integrity sha512-eqyg1Gm7INmRp2+NivRj4ouASz3RNaL0+LkuFsojYnlvLbyhNd3nVdet+OKYPjTN/AdM9WTPQsfvTf4fEhj0Sw==
+  dependencies:
+    argv-split "^2.0.1"
+    fastest-levenshtein "^1.0.12"
+    fs-extra "^9.0.1"
+    hook-emitter "^4.1.0"
+    lodash.camelcase "^4.3.0"
+    pkg-dir "^5.0.0"
+    pluralize "^8.0.0"
+    semver "^7.3.2"
+    snooplogg "^3.0.0"
+    source-map-support "^0.5.19"
+    which "^2.0.2"
+    ws "^7.4.0"
 
 cli-spinners@^2.0.0, cli-spinners@^2.4.0:
   version "2.5.0"
@@ -6408,7 +6390,7 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hook-emitter@^4.0.0, hook-emitter@^4.0.2, hook-emitter@^4.1.0:
+hook-emitter@^4.0.0, hook-emitter@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/hook-emitter/-/hook-emitter-4.1.0.tgz#c9e94556e361986e8b34f036e3d4d2ec59c25c64"
   integrity sha512-6yGJ+q+TBFtvk++Y4xCzj6QhZCLgDmOi4D7wClNFowto96OMBjr3dDPAgOJQpjzJV/FeFDZPh8KEWbu6vbnTGw==
@@ -10648,7 +10630,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semve
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.0, semver@^7.3.2:
+semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -11777,9 +11759,9 @@ type-fest@^0.11.0:
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
 type-fest@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.0.tgz#2edfa6382d48653707344f7fccdb0443d460e8d6"
-  integrity sha512-fbDukFPnJBdn2eZ3RR+5mK2slHLFd6gYHY7jna1KWWy4Yr4XysHuCdXRzy+RiG/HwG4WJat00vdC2UHky5eKiQ==
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
+  integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
 
 type-fest@^0.3.0:
   version "0.3.1"
@@ -12372,7 +12354,7 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^7.2.3, ws@^7.4.0:
+ws@^7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.0.tgz#a5dd76a24197940d4a8bb9e0e152bb4503764da7"
   integrity sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==


### PR DESCRIPTION
fix(auth-sdk:login): Handle stale access tokens when finding an account by removing the now invalid token.
fix(auth-sdk:login): Fixed bug where invalid accounts were not being removed from the token store.
fix(auth-sdk:switch): Validate account before initiating the org switch.
fix(auth-cli:login): Fixed logged in message after logging in using a service account which has no platform organization.
fix(auth-cli:login): Load session after manually logging in.
fix(registry-sdk): Check correct status code to determine if package is found.
fix(amplify-sdk:auth): Don't load account session when doing a manual login.