### PR TITLE
ci: add github actions to lint and run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+on:
+  - pull_request
+  - push
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: yarn
+      - name: Lint
+        run: yarn run gulp lint
+
+  Test:
+    needs: Lint
+    name: ${{ matrix.os }} ${{ matrix.nodeVersion }} Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: 
+        nodeVersion: [ '10.19.0', '12.18.0', '14.15.1' ]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.nodeVersion }}
+      - name: Install dependencies
+        run: yarn
+      - name: Run tests
+        run: yarn run test


### PR DESCRIPTION
See https://github.com/ewanharris/amplify-tooling/actions for an example of the runs. Anecdotally, I've noticed with yarn that it tends to suffer more from network issues when installing dependencies, so that might cause an error occasionally when the cache is cold