### PR TITLE
Amplify SDK authentication proxy fix

### DIFF
--- a/packages/amplify-sdk/CHANGELOG.md
+++ b/packages/amplify-sdk/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.1.4 (May 10, 2021)
+
+ * fix(auth): Pass the `AmplifySDK` `got` instance into the `Auth` class so that it can pass it
+   along to the `Authentication` class. ([CLI-124](https://jira.axway.com/browse/CLI-124))
+ * fix: Added missing `interactiveLoginTimeout` param to login.
+
 # v2.1.3 (Apr 29, 2021)
 
  * chore: Republishing 2.1.2 because it was published out-of-band and lerna is confused.

--- a/packages/amplify-sdk/src/amplify-sdk.js
+++ b/packages/amplify-sdk/src/amplify-sdk.js
@@ -56,6 +56,9 @@ export default class AmplifySDK {
 		 * @type {Function}
 		 */
 		this.got = request.init(opts.requestOptions);
+		if (!opts.got) {
+			opts.got = this.got;
+		}
 
 		/**
 		 * The base Axway ID URL.

--- a/packages/amplify-sdk/src/auth.js
+++ b/packages/amplify-sdk/src/auth.js
@@ -42,6 +42,8 @@ export default class Auth {
 	 * @param {String} [opts.clientSecret] - The secret token to use to authenticate.
 	 * @param {String} [opts.env=prod] - The environment name. Must be `dev`, `preprod`, or `prod`.
 	 * The environment is a shorthand way of specifying a Axway default base URL.
+	 * @param {Function} [opts.got] - A reference to a `got` HTTP client. If not defined, the
+	 * default `got` instance will be used.
 	 * @param {String} [opts.homeDir] - The path to the home directory containing the `lib`
 	 * directory where `keytar` is located. This option is required when `tokenStoreType` is set to
 	 * `secure`, which is the default.
@@ -78,7 +80,8 @@ export default class Auth {
 			clientId:       { value: opts.clientId },
 			clientSecret:   { value: opts.clientSecret },
 			env:            { value: opts.env },
-			got:            { value: request.init(opts.requestOptions) },
+			got:            { value: opts.got || request.init(opts.requestOptions) },
+			interactiveLoginTimeout: { value: opts.interactiveLoginTimeout },
 			messages:       { value: opts.messages },
 			password:       { value: opts.password },
 			realm:          { value: opts.realm },
@@ -158,6 +161,7 @@ export default class Auth {
 			clientId:       opts.clientId || this.clientId,
 			clientSecret:   opts.clientSecret || this.clientSecret,
 			env:            name,
+			got:            opts.got || this.got,
 			messages:       opts.messages || this.messages,
 			password:       opts.password || this.password,
 			platformUrl:    opts.platformUrl || this.platformUrl,


### PR DESCRIPTION
fix(auth): Pass the 'AmplifySDK' 'got()' instance into the 'Auth' class so that it can pass it along to the 'Authentication' class. Fixes CLI-124.