### PR TITLE
Hide --username and --password

### DIFF
--- a/packages/amplify-cli-auth/CHANGELOG.md
+++ b/packages/amplify-cli-auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.6.5
+
+ * chore: Hid the `--username` and `--password` login options since username/password flow does not
+   work and confuses users. ([APIGOV-19103](https://jira.axway.com/browse/APIGOV-19103))
+
 # v2.6.4 (May 11, 2021)
 
  * fix: Added environment name to `axway auth list`.

--- a/packages/amplify-cli-auth/README.md
+++ b/packages/amplify-cli-auth/README.md
@@ -41,12 +41,6 @@ axway auth login
 
 axway auth login --json
 
-axway auth login --username
-
-axway auth login --username <username>
-
-axway auth login --username <username> --password <password>
-
 axway auth login --secret <CLIENT_SECRET>
 
 axway auth login --secret-file <path/to/pem/file>

--- a/packages/amplify-cli-auth/src/commands/login.js
+++ b/packages/amplify-cli-auth/src/commands/login.js
@@ -39,8 +39,14 @@ export default {
 		'-c, --client-secret [key]': 'A secret key used to authenticate',
 		'-s, --secret-file [path]':  'Path to the PEM key used to authenticate',
 		'--service':                 'Authenticates client secret for non-platform service account',
-		'-u, --username [user]':     'Username to authenticate with',
-		'-p, --password [pass]':     'Password to authenticate with'
+		'-u, --username [user]': {
+			desc: 'Username to authenticate with',
+			hidden: true
+		},
+		'-p, --password [pass]': {
+			desc: 'Password to authenticate with',
+			hidden: true
+		}
 	},
 	async action({ argv, cli, console }) {
 		const { default: snooplogg } = require('snooplogg');


### PR DESCRIPTION
chore(auth): Hid the --username and --password login options since username/password flow does not work and confuses users. Fixes APIGOV-19103.