### PR TITLE
Fixed logout and switch for platform tooling accounts.

### DIFF
--- a/packages/amplify-cli-auth/CHANGELOG.md
+++ b/packages/amplify-cli-auth/CHANGELOG.md
@@ -3,6 +3,8 @@
  * feat: Add support for authenticating into a service account, then upgrade to a platform account
    using the platform tooling credentials.
    ([APIGOV-19229](https://jira.axway.com/browse/APIGOV-19229))
+ * fix(switch): Add support for switching org for platform tooling accounts.
+   ([APIGOV-19370](https://jira.axway.com/browse/APIGOV-19370))
  * fix: Remove `--service` flag and treat `--client-secret` auth flows to be headless.
 
 # v2.6.4 (May 11, 2021)

--- a/packages/amplify-sdk/CHANGELOG.md
+++ b/packages/amplify-sdk/CHANGELOG.md
@@ -6,12 +6,17 @@
  * feat: Updated `appcd-fs` to add support for applying parent directory ownership when being
    executed as sudo. ([APIGOV-19102](https://jira.axway.com/browse/APIGOV-19102))
  * feat: Added list of teams to find org info.
+ * fix(switch): Added `isPlatformTooling` flag to properly handle logging out of a platform tooling
+   account. ([APIGOV-19370](https://jira.axway.com/browse/APIGOV-19370))
  * fix: Validate team argument for user add, list, and update commands.
    ([APIGOV-19216](https://jira.axway.com/browse/APIGOV-19216))
  * fix(teams): Allow team user management commands to case insensitive match team name or guid and
    match user by email address or guid.
    ([APIGOV-19105](https://jira.axway.com/browse/APIGOV-19105))
  * fix: Parse activity and usage dates using current locale.
+ * fix: Fixed platform URL reference in switch org logic.
+ * chore: Removed child organizations from organization info. Platform has deprecated parent/child
+   organizations. This also solves an issue where users of child orgs cannot view the parent org.
 
 # v2.1.5 (May 11, 2021)
 

--- a/packages/amplify-sdk/test/test-sdk.js
+++ b/packages/amplify-sdk/test/test-sdk.js
@@ -370,18 +370,6 @@ describe('amplify-sdk', () => {
 
 				await expect(sdk.org.find(account, 'wiz')).to.eventually.be.rejectedWith(Error, 'Unable to find the organization "wiz"');
 			});
-
-			it('should find an org with a parent org', async function () {
-				this.timeout(10000);
-				this.server = await createServer();
-
-				const { account, tokenStore } = this.server.createTokenStore();
-				const sdk = createSDK({ tokenStore });
-
-				let org = await sdk.org.find(account, 200);
-				expect(org.guid).to.equal('2000');
-				expect(org.parentOrg.guid).to.equal('1000');
-			});
 		});
 
 		describe('environments()', () => {

--- a/packages/axway-cli-oum/CHANGELOG.md
+++ b/packages/axway-cli-oum/CHANGELOG.md
@@ -5,6 +5,7 @@
    ([APIGOV-19215](https://jira.axway.com/browse/APIGOV-19215))
  * fix(org:view): Don't show child org section if there are no child orgs.
  * fix(util): Fixed typo in platform account assertion.
+ * chore(org:view): Removed child organizations from `org view`.
 
 # v1.1.3 (May 11, 2021)
 

--- a/packages/axway-cli-oum/src/org/view.js
+++ b/packages/axway-cli-oum/src/org/view.js
@@ -37,9 +37,6 @@ export default {
 		console.log(`  Org ID:        ${highlight(org.id)}`);
 		console.log(`  Org GUID:      ${highlight(org.guid)}`);
 		console.log(`  Date Created:  ${highlight(new Date(org.created).toLocaleString())}`);
-		if (org.parentOrg) {
-			console.log(`  Parent Org:    ${highlight(org.parentOrg.name)} ${note(`(${org.parentOrg.id})`)}`);
-		}
 		console.log(`  Active:        ${highlight(org.active ? 'Yes' : 'No')}`);
 		console.log(`  Region:        ${highlight(org.region === 'US' ? 'United States' : org.region)}`);
 		console.log(`  Users:         ${highlight(`${org.userCount} user${org.userCount !== 1 ? 's' : ''}${org.seats ? ` / ${org.seats} seat${org.seats !== 1 ? 's' : ''}` : ''}`)}`);
@@ -78,21 +75,6 @@ export default {
 			}
 			console.log('\nSUBSCRIPTIONS');
 			console.log(subs.toString());
-		}
-
-		if (Array.isArray(org.childOrgs) && org.childOrgs.length) {
-			const children = createTable([ '  Name', 'GUID', 'Date Created', 'Status', 'Users' ]);
-			for (const o of org.childOrgs) {
-				children.push([
-					`  ${o.name}`,
-					o.guid,
-					new Date(o.created).toLocaleDateString(),
-					o.active ? 'Active' : 'Inactive',
-					o.userCount
-				]);
-			}
-			console.log('\nCHILD ORGS');
-			console.log(children.toString());
 		}
 	}
 };

--- a/test/org/test-org.js
+++ b/test/org/test-org.js
@@ -66,14 +66,7 @@ describe('axway org', () => {
 				"account": "test_client:foo@bar.com",
 					"org": {
 						"active": true,
-						"childOrgs": [
-							{
-								"active": true,
-								"guid": "2000",
-								"name": "Bar org",
-								"userCount": 1
-							}
-						],
+						"childOrgs": null,
 						"guid": "1000",
 						"id": 100,
 						"name": "Foo org",


### PR DESCRIPTION
* fix(auth-cli:switch): Add support for switching org for platform tooling accounts. Fixes [APIGOV-19370](https://jira.axway.com/browse/APIGOV-19370).
* fix(amplify-sdk:switch): Added  flag to properly handle logging out of a platform tooling account. Fixes [APIGOV-19370](https://jira.axway.com/browse/APIGOV-19370).
* fix(amplify-sdk): Fixed platform URL reference in switch org logic.
* chore(amplify-sdk): Removed child organizations from organization info. Platform has deprecated parent/child organizations. This also solves an issue where users of child orgs cannot view the parent org.
* chore(oum-cli:org:view): Removed child organizations from .