### PR TITLE
fix(oum): Properly validate account name and error when a service account is specified.

### DIFF
--- a/packages/axway-cli-oum/CHANGELOG.md
+++ b/packages/axway-cli-oum/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.2.1
+
+ * fix: Properly validate account name and error when a service account is specified.
+   ([APIGOV-19678](https://jira.axway.com/browse/APIGOV-19678))
+
 # v1.2.0 (Jul 30, 2021)
 
  * feat(org:view): Show list of org teams.

--- a/packages/axway-cli-oum/src/lib/util.js
+++ b/packages/axway-cli-oum/src/lib/util.js
@@ -24,7 +24,13 @@ export async function initPlatformAccount(accountName, org) {
 	const { config, sdk } = initSDK();
 	const account = await sdk.auth.find(accountName || config.get('auth.defaultAccount'));
 
-	if (!account || !account.isPlatform) {
+	if (accountName) {
+		if (!account) {
+			throw new Error(`Account "${accountName}" not found`);
+		} else if (!account.isPlatform) {
+			throw new Error(`Account "${accountName}" is not a platform account\n\nTo login, run: axway auth login`);
+		}
+	} else if (!account || !account.isPlatform) {
 		throw new Error('You must be logged into a platform account\n\nTo login, run: axway auth login');
 	}
 

--- a/test/org/list/non-existent-account.mustache
+++ b/test/org/list/non-existent-account.mustache
@@ -1,0 +1,1 @@
+{{#red}}  {{x}} Error: Account "foo" not found{{/red}}

--- a/test/org/list/not-platform-account.mustache
+++ b/test/org/list/not-platform-account.mustache
@@ -1,0 +1,3 @@
+{{#red}}  {{x}} Error: Account "test_client:service@bar.com" is not a platform account{{/red}}
+
+{{#red}}  To login, run: axway auth login{{/red}}

--- a/test/org/test-org.js
+++ b/test/org/test-org.js
@@ -170,6 +170,24 @@ describe('axway org', () => {
 			expect(stderr).to.match(renderRegexFromFile('list/not-authenticated'));
 		});
 
+		it('should error if account is not found', async function() {
+			initHomeDir('home-local');
+
+			const { status, stderr } = await runAxwaySync([ 'org', 'list', '--account', 'foo' ]);
+			expect(status).to.equal(1);
+			expect(stderr).to.match(renderRegexFromFile('list/non-existent-account'));
+		});
+
+		it('should error if account is not a platform account', async function() {
+			initHomeDir('home-local');
+			this.servers = await startServers();
+			const { name } = JSON.parse((await runAxwaySync([ 'auth', 'login', '--client-secret', 'shhhh', '--json' ])).stdout);
+
+			const { status, stderr } = await runAxwaySync([ 'org', 'list', '--account', name ]);
+			expect(status).to.equal(1);
+			expect(stderr).to.match(renderRegexFromFile('list/not-platform-account'));
+		});
+
 		it('should list all orgs', async function() {
 			initHomeDir('home-local');
 			this.servers = await startServers();


### PR DESCRIPTION
JIRA: https://jira.axway.com/browse/APIGOV-19678

To test:

1. While logged out, run `axway org list` to error with not logged in message.
2. While logged in as a service account, `axway org list` to error with not a platform account message.
3. While logged in or out, run `axway org list --account foo` to error with account "foo" not found.