### PR TITLE
fix(auth): Remove env from account hash when prod

### DIFF
--- a/packages/amplify-cli-utils/test/test-auth.js
+++ b/packages/amplify-cli-utils/test/test-auth.js
@@ -106,7 +106,7 @@ describe('auth', () => {
 					access_token: 'foo'
 				}
 			},
-			hash: 'test:e68e2ebbfd6a18595992efddf4f7b288',
+			hash: 'test:85e0419f4473118bf2bc8a8bba9f6abc',
 			name: 'bar'
 		};
 
@@ -121,7 +121,7 @@ describe('auth', () => {
 			platformUrl:  'http://127.0.0.1:1337/',
 			realm:        'baz',
 			tokenStore
-		}, new Config());
+		}, new Config({ env: 'preprod' }));
 
 		const account = await sdk.auth.find();
 		expect(account).to.deep.equal(token);

--- a/packages/amplify-sdk/CHANGELOG.md
+++ b/packages/amplify-sdk/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v3.0.1
+
+ * fix(auth): Only include the env in the authenticated account hash when the env is not
+   production. ([APIGOV-20704](https://jira.axway.com/browse/APIGOV-20704))
+
 # v3.0.0 (Sep 24, 2021)
 
  * BREAKING CHANGE: Require Node.js 12.13.0 LTS or newer.

--- a/packages/amplify-sdk/src/authenticators/authenticator.js
+++ b/packages/amplify-sdk/src/authenticators/authenticator.js
@@ -398,7 +398,7 @@ export default class Authenticator {
 	get hash() {
 		return this.clientId.replace(/\s/g, '_').replace(/_+/g, '_') + ':' + md5(Object.assign({
 			baseUrl:  this.baseUrl,
-			env:      this.env.name,
+			env:      this.env.name === 'prod' ? undefined : this.env.name,
 			realm:    this.realm
 		}, this.hashParams));
 	}

--- a/test/pm/test-pm.js
+++ b/test/pm/test-pm.js
@@ -250,7 +250,7 @@ describe('axway pm', () => {
 
 		it('should handle update a package', async function () {
 			this.timeout(120000);
-			this.slow(30000);
+			this.slow(60000);
 
 			await runAxwaySync([ 'pm', 'install', 'acs@2.1.9' ]);
 
@@ -270,13 +270,13 @@ describe('axway pm', () => {
 
 		it('should handle no packages to update', async function () {
 			this.timeout(120000);
-			this.slow(30000);
+			this.slow(60000);
 
 			let { status, stdout } = await runAxwaySync([ 'pm', 'update' ]);
 			expect(status).to.equal(0);
 			expect(stdout).to.match(renderRegexFromFile('update/nothing-to-update'));
 
-			await runAxwaySync([ 'pm', 'install', 'acs@2.1.10' ]);
+			await runAxwaySync([ 'pm', 'install', 'acs' ]);
 
 			( { status, stdout } = await runAxwaySync([ 'pm', 'update' ]));
 			expect(status).to.equal(0);
@@ -285,7 +285,7 @@ describe('axway pm', () => {
 
 		it('should error updating a package that is not installed', async function () {
 			this.timeout(120000);
-			this.slow(30000);
+			this.slow(60000);
 
 			const { status, stderr } = await runAxwaySync([ 'pm', 'update', 'acs' ]);
 			expect(status).to.equal(1);

--- a/test/pm/update/updated-acs.mustache
+++ b/test/pm/update/updated-acs.mustache
@@ -5,11 +5,11 @@ The following packages have updates available:
 
   {{#bold}}acs{{/bold}}  2.1.9  →  {{versionWithColor}}
 
-Downloading and installing {{#cyan}}acs@2.1.10{{/cyan}} [started]
-Downloading {{#cyan}}acs@2.1.10{{/cyan}}
-Installing {{#cyan}}acs@2.1.10{{/cyan}}
-Registering {{#cyan}}acs@2.1.10{{/cyan}}
-{{#cyan}}acs@2.1.10{{/cyan}} installed and set as active version [completed]
+Downloading and installing {{#cyan}}acs@{{version}}{{/cyan}} [started]
+Downloading {{#cyan}}acs@{{version}}{{/cyan}}
+Installing {{#cyan}}acs@{{version}}{{/cyan}}
+Registering {{#cyan}}acs@{{version}}{{/cyan}}
+{{#cyan}}acs@{{version}}{{/cyan}} installed and set as active version [completed]
 
 The following package versions can be purged:
 


### PR DESCRIPTION
JIRA: https://jira.axway.com/browse/APIGOV-20704

fix(auth): Only include the env in the authenticated account hash when the env is not production.