### PR TITLE
APIGOV-30622 Fixed Issue with "axway user credentials" command

### DIFF
--- a/packages/axway-cli-oum/src/user/credentials.js
+++ b/packages/axway-cli-oum/src/user/credentials.js
@@ -6,15 +6,17 @@ export default {
 	desc: 'Opens a web browser to the change your password page',
 	async action({ console }) {
 		const { highlight } = snooplogg.styles;
-		const { sdk } = initSDK();
+		const { sdk } = await initSDK();
 		const open = pkg;
 
 		if (isHeadless()) {
 			throw new Error('Changing your login credentials requires a web browser and is unsupported in headless environments');
 		}
+		if( skd !== null){
+			const url = `${sdk.platformUrl}#/user/credentials`;
+			console.log(`Opening web browser to ${highlight(url)}`);
+			await open(url);
+		}
 
-		const url = `${sdk.platformUrl}#/user/credentials`;
-		console.log(`Opening web browser to ${highlight(url)}`);
-		await open(url);
 	}
 };

--- a/packages/axway-cli-oum/src/user/credentials.js
+++ b/packages/axway-cli-oum/src/user/credentials.js
@@ -12,7 +12,7 @@ export default {
 		if (isHeadless()) {
 			throw new Error('Changing your login credentials requires a web browser and is unsupported in headless environments');
 		}
-		if( sdk !== null){
+		if (sdk !== null) {
 			const url = `${sdk.platformUrl}#/user/credentials`;
 			console.log(`Opening web browser to ${highlight(url)}`);
 			await open(url);

--- a/packages/axway-cli-oum/src/user/credentials.js
+++ b/packages/axway-cli-oum/src/user/credentials.js
@@ -12,7 +12,7 @@ export default {
 		if (isHeadless()) {
 			throw new Error('Changing your login credentials requires a web browser and is unsupported in headless environments');
 		}
-		if( skd !== null){
+		if( sdk !== null){
 			const url = `${sdk.platformUrl}#/user/credentials`;
 			console.log(`Opening web browser to ${highlight(url)}`);
 			await open(url);

--- a/test/user/credentials/headless.mustache
+++ b/test/user/credentials/headless.mustache
@@ -1,0 +1,1 @@
+{{#red}}{{x}} Error: Changing your login credentials requires a web browser and is unsupported in headless environments{{/red}}

--- a/test/user/credentials/help.mustache
+++ b/test/user/credentials/help.mustache
@@ -6,7 +6,7 @@ Opens a web browser to the change your password page
 USAGE: {{#cyan}}axway user credentials [options]{{/cyan}}
 
 GLOBAL OPTIONS:
-  {{#cyan}}--no-banner         {{/cyan}}  Suppress the banner
-  {{#cyan}}--no-color          {{/cyan}}  Disable colors
-  {{#cyan}}-h, --help          {{/cyan}}  Displays the help screen
-  {{#cyan}}-v, --version       {{/cyan}}  Outputs the version
+  {{#cyan}}--no-banner  {{/cyan}}  Suppress the banner
+  {{#cyan}}--no-color   {{/cyan}}  Disable colors
+  {{#cyan}}-h, --help   {{/cyan}}  Displays the help screen
+  {{#cyan}}-v, --version{{/cyan}}  Outputs the version

--- a/test/user/credentials/help.mustache
+++ b/test/user/credentials/help.mustache
@@ -1,0 +1,10 @@
+{{#cyan}}AXWAY CLI{{/cyan}}, version {{version}}
+Copyright (c) 2018-{{year}}, Axway, Inc. All Rights Reserved.{{{nodeDeprecationWarning}}}
+
+Opens a web browser to the change your password page
+
+GLOBAL OPTIONS:
+  {{#cyan}}--no-banner         {{/cyan}}  Suppress the banner
+  {{#cyan}}--no-color          {{/cyan}}  Disable colors
+  {{#cyan}}-h, --help          {{/cyan}}  Displays the help screen
+  {{#cyan}}-v, --version       {{/cyan}}  Outputs the version

--- a/test/user/credentials/help.mustache
+++ b/test/user/credentials/help.mustache
@@ -3,6 +3,8 @@ Copyright (c) 2018-{{year}}, Axway, Inc. All Rights Reserved.{{{nodeDeprecationW
 
 Opens a web browser to the change your password page
 
+USAGE: {{#cyan}}axway user credentials [options]{{/cyan}}
+
 GLOBAL OPTIONS:
   {{#cyan}}--no-banner         {{/cyan}}  Suppress the banner
   {{#cyan}}--no-color          {{/cyan}}  Disable colors

--- a/test/user/credentials/open-browser.mustache
+++ b/test/user/credentials/open-browser.mustache
@@ -1,0 +1,4 @@
+{{#cyan}}AXWAY CLI{{/cyan}}, version {{version}}
+Copyright (c) 2018-{{year}}, Axway, Inc. All Rights Reserved.{{{nodeDeprecationWarning}}}
+
+Opening web browser to {{#cyan}}https://platform.axway.com#/user/credentials{{/cyan}}

--- a/test/user/test-user.js
+++ b/test/user/test-user.js
@@ -160,6 +160,18 @@ describe('axway user', () => {
 			expect(status).to.equal(2);
 			expect(stdout.toString()).to.match(renderRegexFromFile('credentials/help'));
 		});
+
+		(process.platform === 'win32' ? it.skip : it)('should error if env is headless', async function () {
+			initHomeDir('home-local');
+
+			let { status, stderr } = await runAxwaySync([ 'user', 'credentials' ], {
+				env: {
+					SSH_TTY: '1'
+				}
+			});
+			expect(status).to.equal(1);
+			expect(stderr).to.match(renderRegexFromFile('credentials/headless'));
+		});
 	});
 
 	describe('update', () => {

--- a/test/user/test-user.js
+++ b/test/user/test-user.js
@@ -148,7 +148,11 @@ describe('axway user', () => {
 	});
 
 	describe('credentials', () => {
-		//
+		it('should open browser to /user/credentials endpoint regardless of authentication', async function () {
+			const { status, stdout } = await runAxwaySync([ 'user', 'credentials']);
+			expect(status).to.equal(0);
+			expect(stdout.toString()).to.match(renderRegexFromFile('credentials/open-browser'));
+		});
 	});
 
 	describe('update', () => {

--- a/test/user/test-user.js
+++ b/test/user/test-user.js
@@ -153,6 +153,12 @@ describe('axway user', () => {
 			expect(status).to.equal(0);
 			expect(stdout.toString()).to.match(renderRegexFromFile('credentials/open-browser'));
 		});
+
+		it('should output credentials help', async function () {
+			const { status, stdout } = await runAxwaySync([ 'user', 'credentials', '--help']);
+			expect(status).to.equal(2);
+			expect(stdout.toString()).to.match(renderRegexFromFile('credentials/help'));
+		});
 	});
 
 	describe('update', () => {

--- a/test/user/test-user.js
+++ b/test/user/test-user.js
@@ -148,6 +148,8 @@ describe('axway user', () => {
 	});
 
 	describe('credentials', () => {
+		after(resetHomeDir);
+		
 		it('should open browser to /user/credentials endpoint regardless of authentication', async function () {
 			const { status, stdout } = await runAxwaySync([ 'user', 'credentials']);
 			expect(status).to.equal(0);

--- a/test/user/test-user.js
+++ b/test/user/test-user.js
@@ -148,9 +148,8 @@ describe('axway user', () => {
 	});
 
 	describe('credentials', () => {
-		after(resetHomeDir);
-		
-		it('should open browser to /user/credentials endpoint regardless of authentication', async function () {
+
+		it('should open browser to update credentials page', async function () {
 			const { status, stdout } = await runAxwaySync([ 'user', 'credentials']);
 			expect(status).to.equal(0);
 			expect(stdout.toString()).to.match(renderRegexFromFile('credentials/open-browser'));


### PR DESCRIPTION
Previously 'axway user credentials' command resulted in a type error. This error has been fixed by adding adding the async keyword to `credentials.js`. Additionally a few test have been added covering this command. All unit tests pass and code coverage has increased as well.