### PR TITLE
APIGOV-32150 Axway CLI needs to support the new Engage Preprod

### DIFF
--- a/docs/Release Notes/Axway CLI 4.0.6.md
+++ b/docs/Release Notes/Axway CLI 4.0.6.md
@@ -1,0 +1,67 @@
+# Axway CLI 4.1.0
+
+## March 03, 2026
+
+This is a minor release to include support for preproduction environment.
+
+### Installation
+
+```
+npm i -g axway@4.1.0
+```
+
+### axway
+
+- **v4.1.0** - 01/22/2026
+  - chore: Add support for preproduction environment.
+    ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
+### amplify-cli-utils
+
+- **v6.1.0** - 01/22/2026
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
+### amplify-config
+
+- **v5.1.0** - 01/22/2026
+  - chore: Add support for preproduction environment.
+    ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
+### amplify-request
+
+- **v4.1.0** - 01/22/2026
+  - chore: Add support for preproduction environment.
+    ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
+### amplify-sdk
+
+- **v4.1.0** - 01/22/2026
+  - chore: Add support for preproduction environment.
+    ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
+### amplify-utils
+
+- **v2.1.0** - 01/22/2026
+  - chore: Add support for preproduction environment.
+    ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
+### axway-cli-auth
+
+- **v4.1.0** - 01/22/2026
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
+### axway-cli-oum
+
+- **v3.1.0** - 01/22/2026
+  - chore: Add support for preproduction environment.
+    ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
+### axway-cli-pm
+
+- **v5.1.0** - 01/22/2026
+  - chore: Add support for preproduction environment.
+    ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))

--- a/packages/amplify-cli-utils/CHANGELOG.md
+++ b/packages/amplify-cli-utils/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v6.1.0 (Mar 03, 2026)
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
 # v6.0.6 (Jan 22, 2026)
 
 - chore: Fixed Issue with org select redirection timeout.

--- a/packages/amplify-cli-utils/package.json
+++ b/packages/amplify-cli-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway/amplify-cli-utils",
-  "version": "6.0.6",
+  "version": "6.1.0",
   "publishConfig": {
     "access": "public"
   },
@@ -24,9 +24,9 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@axway/amplify-config": "^5.0.6",
-    "@axway/amplify-request": "^4.0.6",
-    "@axway/amplify-sdk": "^4.0.6",
+    "@axway/amplify-config": "^5.1.0",
+    "@axway/amplify-request": "^4.1.0",
+    "@axway/amplify-sdk": "^4.1.0",
     "boxen": "^8.0.1",
     "check-kit": "^4.0.0",
     "cli-kit": "^2.1.1",

--- a/packages/amplify-cli-utils/src/environments.js
+++ b/packages/amplify-cli-utils/src/environments.js
@@ -39,9 +39,6 @@ export const environments = {
 			clientId: 'amplify-cli',
 			realm: 'Broker'
 		},
-		registry: {
-			url: 'https://registry.platform.axway.com'
-		},
 		title: 'PreProduction'
 	}
 };

--- a/packages/amplify-cli-utils/src/environments.js
+++ b/packages/amplify-cli-utils/src/environments.js
@@ -33,14 +33,24 @@ export const environments = {
 			url: 'https://registry.platform.axway.com'
 		},
 		title: 'Production'
+	},
+	preprod: {
+		auth: {
+			clientId: 'amplify-cli',
+			realm: 'Broker'
+		},
+		registry: {
+			url: 'https://registry.platform.axway.com'
+		},
+		title: 'PreProduction'
 	}
 };
 
 const mapping = {
 	development: 'dev',
-	preprod: 'staging',
-	preproduction: 'staging',
-	'pre-production': 'staging',
+	preprod: 'preprod',
+	preproduction: 'preprod',
+	'pre-production': 'preprod',
 	production: 'prod',
 	test: 'staging'
 };

--- a/packages/amplify-config/CHANGELOG.md
+++ b/packages/amplify-config/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v5.1.0 (Mar 03, 2026)
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
 # v5.0.6 (Jan 22, 2026)
 
 - chore: Fixed Issue with org select redirection timeout.

--- a/packages/amplify-config/package.json
+++ b/packages/amplify-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway/amplify-config",
-  "version": "5.0.6",
+  "version": "5.1.0",
   "publishConfig": {
     "access": "public"
   },
@@ -24,7 +24,7 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@axway/amplify-utils": "^2.0.6",
+    "@axway/amplify-utils": "^2.1.0",
     "config-kit": "^2.1.0",
     "fs-extra": "^10.1.0",
     "source-map-support": "^0.5.21"

--- a/packages/amplify-request/CHANGELOG.md
+++ b/packages/amplify-request/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.1.0 (Mar 03, 2026)
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
 # v4.0.6 (Jan 22, 2026)
 
 - chore: Fixed Issue with org select redirection timeout.

--- a/packages/amplify-request/package.json
+++ b/packages/amplify-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway/amplify-request",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "publishConfig": {
     "access": "public"
   },
@@ -28,7 +28,7 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@axway/amplify-utils": "^2.0.6",
+    "@axway/amplify-utils": "^2.1.0",
     "got": "^11.8.5",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.1",

--- a/packages/amplify-sdk/CHANGELOG.md
+++ b/packages/amplify-sdk/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.1.0 (Mar 03, 2026)
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
 # v4.0.6 (Jan 22, 2026)
 
 - chore: Fixed Issue with org select redirection timeout.

--- a/packages/amplify-sdk/package.json
+++ b/packages/amplify-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway/amplify-sdk",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "publishConfig": {
     "access": "public"
   },
@@ -23,8 +23,8 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@axway/amplify-request": "^4.0.6",
-    "@axway/amplify-utils": "^2.0.6",
+    "@axway/amplify-request": "^4.1.0",
+    "@axway/amplify-utils": "^2.1.0",
     "ci-info": "^3.3.1",
     "ejs": "^3.1.10",
     "fs-extra": "^10.1.0",

--- a/packages/amplify-sdk/src/environments.js
+++ b/packages/amplify-sdk/src/environments.js
@@ -13,15 +13,20 @@ export const environments = {
 		baseUrl:     'https://login.axway.com',
 		platformUrl: 'https://platform.axway.com',
 		realm:       'Broker'
+	},
+	preprod: {
+		baseUrl: 'https://login.na-us.axwaypreprod.net',
+		platformUrl: 'https://platform.na-us.axwaypreprod.net',
+		realm: 'Broker'
 	}
 };
 
 const mapping = {
 	dev: 'staging',
 	development: 'staging',
-	preprod: 'staging',
-	preproduction: 'staging',
-	'pre-production': 'staging',
+	preprod: 'preprod',
+	preproduction: 'preprod',
+	'pre-production': 'preprod',
 	production: 'prod',
 	test: 'staging'
 };

--- a/packages/amplify-utils/CHANGELOG.md
+++ b/packages/amplify-utils/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.1.0 (Mar 03, 2026)
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
 # v2.0.6 (Jan 22, 2026)
 
 - chore: Fixed Issue with org select redirection timeout.

--- a/packages/amplify-utils/package.json
+++ b/packages/amplify-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway/amplify-utils",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/axway-cli-auth/CHANGELOG.md
+++ b/packages/axway-cli-auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.1.0 (Mar 03, 2026)
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
 # v4.0.6 (Jan 22, 2026)
 
 - chore: Fixed Issue with org select redirection timeout.

--- a/packages/axway-cli-auth/package.json
+++ b/packages/axway-cli-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway/axway-cli-auth",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "publishConfig": {
     "access": "public"
   },
@@ -23,8 +23,8 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@axway/amplify-cli-utils": "^6.0.6",
-    "@axway/amplify-utils": "^2.0.6",
+    "@axway/amplify-cli-utils": "^6.1.0",
+    "@axway/amplify-utils": "^2.1.0",
     "cli-kit": "github:kasuvy/cli-kit#APIGOV-29723",
     "enquirer": "^2.3.6",
     "pretty-ms": "^7.0.1",

--- a/packages/axway-cli-oum/CHANGELOG.md
+++ b/packages/axway-cli-oum/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v3.1.0 (Mar 03, 2026)
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
 # v3.0.6 (Jan 22, 2026)
 
 - chore: Fixed Issue with org select redirection timeout.

--- a/packages/axway-cli-oum/package.json
+++ b/packages/axway-cli-oum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway/axway-cli-oum",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "publishConfig": {
     "access": "public"
   },
@@ -22,7 +22,7 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@axway/amplify-cli-utils": "^6.0.6",
+    "@axway/amplify-cli-utils": "^6.1.0",
     "cli-kit": "^2.1.1",
     "open": "^8.4.0",
     "snooplogg": "^5.1.0",

--- a/packages/axway-cli-pm/CHANGELOG.md
+++ b/packages/axway-cli-pm/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v5.1.0 (Mar 03, 2026)
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
 # v5.0.6 (Jan 22, 2026)
 
 - chore: Fixed Issue with org select redirection timeout.

--- a/packages/axway-cli-pm/package.json
+++ b/packages/axway-cli-pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway/axway-cli-pm",
-  "version": "5.0.6",
+  "version": "5.1.0",
   "publishConfig": {
     "access": "public"
   },
@@ -22,8 +22,8 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@axway/amplify-cli-utils": "^6.0.6",
-    "@axway/amplify-utils": "^2.0.6",
+    "@axway/amplify-cli-utils": "^6.1.0",
+    "@axway/amplify-utils": "^2.1.0",
     "cli-kit": "^2.1.1",
     "cross-spawn": "^7.0.3",
     "fs-extra": "^10.1.0",

--- a/packages/axway-cli/CHANGELOG.md
+++ b/packages/axway-cli/CHANGELOG.md
@@ -1,4 +1,9 @@
-# v4.0.6 (Jan 22, 2026)
+# v4.1.0 (Mar 03, 2026)
+
+- chore: Add support for preproduction environment.
+  ([APIGOV-32150](https://jira.axway.com/browse/APIGOV-32150))
+
+# v4.0.5 (Jan 22, 2026)
 
 - chore: Fixed Issue with org select redirection timeout.
   ([APIGOV-30889](https://jira.axway.com/browse/APIGOV-30889))

--- a/packages/axway-cli/package.json
+++ b/packages/axway-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axway",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "publishConfig": {
     "access": "public"
   },
@@ -28,11 +28,11 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@axway/amplify-cli-utils": "^6.0.6",
-    "@axway/amplify-utils": "^2.0.6",
-    "@axway/axway-cli-auth": "^4.0.6",
-    "@axway/axway-cli-oum": "^3.0.6",
-    "@axway/axway-cli-pm": "^5.0.6",
+    "@axway/amplify-cli-utils": "^6.1.0",
+    "@axway/amplify-utils": "^2.1.0",
+    "@axway/axway-cli-auth": "^4.1.0",
+    "@axway/axway-cli-oum": "^3.1.0",
+    "@axway/axway-cli-pm": "^5.1.0",
     "boxen": "^8.0.1",
     "check-kit": "^4.0.0",
     "cli-kit": "^2.1.1",


### PR DESCRIPTION
Since the new Engage Preprod points to the new Platform preprod, today the Axway Engage CLI does not support it as is. We would eventually need this support since the customers using the Preprod (Bradesco) would be looking forward to use CLI for their testing.