### PR TITLE
APIGOV-32523 Engage CLI - Commands - INSTALL - Agents (On-Prem & SaaS)

### DIFF
--- a/src/lib/engage/clients-external/apiserverclient.ts
+++ b/src/lib/engage/clients-external/apiserverclient.ts
@@ -552,7 +552,7 @@ export class ApiServerClient {
 				scopeName,
 				version,
 			});
-			service.put(`${urlPath}/${subResourceName}?fields=${subResourceName}`, {
+			await service.put(`${urlPath}/${subResourceName}?fields=${subResourceName}`, {
 				[subResourceName]: foundSubResources[subResourceName],
 			});
 		} catch (e: any) {
@@ -1207,9 +1207,8 @@ export class ApiServerClient {
 			pendingResources = await this.checkForResources(resources, sortedDefsArray);
 			const pendingDeletingResource = pendingResources.some((res) => res?.data);
 			if (pendingDeletingResource) {
-				setTimeout(async () => {
-					pendingResources = await this.checkForResources(resources, sortedDefsArray);
-				}, WAIT_TIMEOUT);
+				await new Promise((resolve) => setTimeout(resolve, WAIT_TIMEOUT));
+				pendingResources = await this.checkForResources(resources, sortedDefsArray);
 				const stillPending = pendingResources.some((res) => res?.data);
 				if (stillPending) {
 					const pendingResNames = pendingResources.map((res) => res?.data?.name);

--- a/src/lib/engage/flags.ts
+++ b/src/lib/engage/flags.ts
@@ -12,7 +12,7 @@ export const commonFlags = {
 	region: Flags.string({
 		description: 'Override your region config',
 	}),
-	cache: Flags.boolean({
+	useCache: Flags.boolean({
 		description: 'Use cache when communicating with the server',
 		allowNo: true,
 		default: true,

--- a/src/lib/engage/types.ts
+++ b/src/lib/engage/types.ts
@@ -991,6 +991,11 @@ export enum APIGEEXAuthType {
 	ACCESS_CREDENTIAL = 'Access Credential',
 }
 
+export enum LoggingSource {
+	Event = 'event',
+	OpenTraffic = 'open traffic',
+}
+
 // AWSRegions - base set of regions, may use option outside this list
 export enum AWSRegions {
 	US_EAST_1 = 'us-east-1',
@@ -1132,6 +1137,15 @@ export class IstioInstallValues {
 		this.targetPort = 0;
 	}
 }
+
+export const IstioProfileChoices = [
+	{ name: 'default', value: 'default' },
+	{ name: 'demo', value: 'demo' },
+	{ name: 'empty', value: 'empty' },
+	{ name: 'minimal', value: 'minimal' },
+	{ name: 'openshift', value: 'openshift' },
+	{ name: 'preview', value: 'preview' },
+];
 
 export enum TraceableRegionType {
 	US = 'US',

--- a/src/lib/engage/utils/agents/flows/akamaiAgent.ts
+++ b/src/lib/engage/utils/agents/flows/akamaiAgent.ts
@@ -1,12 +1,16 @@
-import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import chalk from 'chalk';
+import { ApiServerClient } from '../../../clients-external/apiserverclient.js';
+import { DefinitionsManager } from '../../../results/DefinitionsManager.js';
+import { InstallationFlowMethods, svcAccMsg } from '../../../services/install-service.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, GenericResource, PublicDockerRepoBaseUrl, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList, validateRegex, validateValueRange } from '../../basic-prompts.js';
+import { AgentHelmInfo, helmImageSecretInfo, helmInstallInfo, isWindows, writeTemplates } from '../../utils.js';
 import { AkamaiAgentValues } from '../index.js';
 import * as helpers from '../index.js';
+import { kubectl } from '../kubectl.js';
 
-export const askBundleType = async (): Promise<BundleType> => {
-	return  BundleType.TRACEABILITY as BundleType;
-};
+const caImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.AKAMAI_CA}`;
+export const amplifyAgentsNs = 'amplify-agents';
 
 // ConfigFiles - all the config file that are used in the setup
 export const ConfigFiles = {
@@ -27,6 +31,10 @@ const prompts = {
 	environmentsDescription: 'Configure a mapping of Akamai environment to Engage environment that the agent will use',
 };
 
+export const askBundleType = async (): Promise<BundleType> => {
+	return  BundleType.TRACEABILITY as BundleType;
+};
+
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
 	return (await askList({
 		msg: prompts.configTypeMsg,
@@ -34,13 +42,257 @@ export const askConfigType = async (): Promise<AgentConfigTypes> => {
 	})) as AgentConfigTypes;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<AkamaiAgentValues> => {
+//
+// Questions for the configuration of Akamai agents
+//
+const askAkamaiBaseUrl = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterBaseUrl,
+		validate: validateRegex(
+			helpers.AkamaiRegexPatterns.baseURLRegex,
+			helpers.invalidValueExampleErrMsg('baseURL', 'https://akamai.com'),
+		),
+	})) as string;
+
+const askAkamaiClientId = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterClientId,
+	})) as string;
+
+const askAkamaiClientSecret = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterClientSecret,
+	})) as string;
+
+const askAkamaiSegmentLength = async (): Promise<number> =>
+	(await askInput({
+		msg: prompts.enterSegmentLength,
+		type: 'number',
+		validate: validateValueRange(0),
+	})) as number;
+
+const askEnvironments = async (centralEnvs: GenericResource[], akamaiAgentValues: AkamaiAgentValues, excludeEnvironment?: string): Promise<void> => {
+	// Filter out the already-selected agent installation environment
+	if (excludeEnvironment) {
+		centralEnvs = centralEnvs.filter(env => env.name !== excludeEnvironment);
+	}
+
+	// If no central environments are available, exit the installation
+	if (centralEnvs.length === 0) {
+		console.log(chalk.red('Installation cannot proceed: No Engage environments are available for mapping.'));
+		console.log(chalk.yellow('Please create at least one Engage environment before installing the Akamai agent.'));
+		console.log(chalk.gray('You can create an environment using: axway engage create environment'));
+		process.exit(1);
+	}
+
+	let askEnvs = true;
+	const envs = [];
+	const mappedCentralEnvs = [];
+	console.log(chalk.gray(prompts.environmentsDescription));
+	while (askEnvs) {
+		const env = (await askInput({
+			msg: prompts.enterEnvironments,
+			allowEmptyInput: true,
+		})) as string;
+
+		if (envs.length === 0 && (!env || env.toString().trim() === '')) {
+			break;
+		}
+
+		if (env && env.toString().trim() !== '') {
+			envs.push(env);
+		}
+		const centralMappingEnv = await askList({
+			msg: prompts.selectCentralMappingEnvironment,
+			choices: centralEnvs.map((e) => e.name),
+		});
+
+		if (centralMappingEnv && centralMappingEnv.toString().trim() !== '') {
+			mappedCentralEnvs.push(centralMappingEnv);
+		}
+
+		// Remove the selected environment from available choices for next iteration
+		centralEnvs = centralEnvs.filter(env => env.name !== centralMappingEnv);
+
+		// Only ask to continue if there are remaining central environments
+		if (centralEnvs.length > 0) {
+			askEnvs = await askList({
+				msg: prompts.enterMoreEnvironments,
+				default: YesNo.No,
+				choices: YesNoChoices,
+			}) === YesNo.Yes;
+		} else {
+			askEnvs = false; // Auto-stop when no environments remain
+		}
+	}
+
+	akamaiAgentValues.environments = envs;
+	akamaiAgentValues.centralEnvironments = mappedCentralEnvs;
+};
+
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<AkamaiAgentValues> => {
 	const akamaiAgentValues: AkamaiAgentValues = new AkamaiAgentValues();
+
+	if (installConfig.switches.isHelmInstall) {
+		console.log(
+			chalk.gray('The Amplify Akamai Agent needs to be deployed to your Kubernetes cluster to discover APIs for publishing to Amplify Central.')
+		);
+		const { error } = await kubectl.isInstalled();
+		if (error) {
+			throw new Error(
+				`Kubectl is required to fill out the following prompts. It appears to be missing or misconfigured.\n${error}`
+			);
+		}
+		akamaiAgentValues.namespace = await helpers.askNamespace(prompts.agentNamespace, amplifyAgentsNs);
+	}
+
+	if (installConfig.switches.isDockerInstall) {
+		console.log('\nCONNECTION TO AKAMAI API GATEWAY:');
+		console.log(
+			chalk.gray('The Compliance Agent needs to connect to the Akamai API Gateway to discover API\'s for publishing to Amplify Central.')
+		);
+	}
+
+	akamaiAgentValues.baseUrl = await askAkamaiBaseUrl();
+	akamaiAgentValues.clientId = await askAkamaiClientId();
+	akamaiAgentValues.clientSecret = await askAkamaiClientSecret();
+	akamaiAgentValues.segmentLength = await askAkamaiSegmentLength();
+	await helpers.getCentralEnvironments(installConfig.centralConfig.apiServerClient as ApiServerClient, installConfig.centralConfig.definitionManager as DefinitionsManager)
+		.then(async envs => {
+			// eslint-disable-next-line promise/always-return
+			if (envs) {
+				// Pass the already-selected agent installation environment to exclude it from mapping choices
+				const agentInstallEnv = installConfig.centralConfig.ampcEnvInfo?.name;
+				await askEnvironments(envs, akamaiAgentValues, agentInstallEnv);
+			}
+		});
 
 	return akamaiAgentValues;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const dockerSuccessMsg = (installConfig: AgentInstallConfig) => {
+	const runAgentLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.AGENT_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runAgentWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.AGENT_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startAgentLinuxMsg = '\nStart the Akamai Agent on a Linux based machine';
+	const startAgentWinMsg = '\nStart the Akamai Agent on a Windows machine';
+
+	const dockerInfo = `To utilize the agent, pull the latest Docker image and run it using the appropriate supplied environment file, (${helpers.configFiles.AGENT_ENV_VARS}):`;
+	console.log(chalk.whiteBright(dockerInfo), '\n');
+	const caImageVersion = `${caImage}:${installConfig.caVersion}`;
+	console.log(chalk.white('Pull the latest image of the Agent:'));
+	console.log(chalk.cyan(`docker pull ${caImageVersion}`));
+	console.log(chalk.white(isWindows ? startAgentWinMsg : startAgentLinuxMsg));
+	console.log(chalk.cyan(isWindows ? runAgentWinMsg : runAgentLinuxMsg));
+	console.log('\t', chalk.cyan(`-v /data ${caImageVersion}`), '\n');
+};
+
+const helmSuccessMsg = (namespace: string) => {
+	console.log(`Akamai Agent override file has been placed at ${process.cwd()}/${ConfigFiles.helmOverride}`);
+	helmImageSecretInfo(namespace);
+
+	const agentHelmInfo = new Set<AgentHelmInfo>();
+	agentHelmInfo.add({
+		helmReleaseName: 'akamai-agent',
+		helmChartName: ' axway/akamai-agent',
+		overrideFileName: ConfigFiles.helmOverride,
+		imageSecretOverrides: '--set image.pullSecret=<image-pull-secret-name>' });
+
+	helmInstallInfo(
+		'Akamai',
+		namespace,
+		agentHelmInfo
+	);
+};
+
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	const akamaiAgentValues = installConfig.gatewayConfig as AkamaiAgentValues;
+	const configType = installConfig.deploymentType;
+
+	if (installConfig.centralConfig.ampcDosaInfo.isNew && !installConfig.switches.isHelmInstall) {
+		console.log(chalk.yellow(svcAccMsg));
+	}
+
+	if (configType === AgentConfigTypes.DOCKERIZED) {
+		dockerSuccessMsg(installConfig);
+	} else if (configType === AgentConfigTypes.HELM) {
+		helmSuccessMsg(
+			akamaiAgentValues.namespace.name
+		);
+	}
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.AKAMAI}`)
+	);
+};
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	// Add final settings to AkamaiAgentValues
+	const akamaiAgentValues = installConfig.gatewayConfig as AkamaiAgentValues;
+	akamaiAgentValues.centralConfig = installConfig.centralConfig;
+	akamaiAgentValues.traceabilityConfig = installConfig.traceabilityConfig;
+
+	if (installConfig.switches.isHelmInstall) {
+		akamaiAgentValues.akamaiSecret = helpers.amplifyAgentsCredsSecret;
+		akamaiAgentValues.agentKeysSecret = helpers.amplifyAgentsKeysSecret;
+		if (akamaiAgentValues.namespace.isNew) {
+			await helpers.createNamespace(akamaiAgentValues.namespace.name);
+		}
+		await helpers.createSecret(akamaiAgentValues.namespace.name, helpers.amplifyAgentsKeysSecret, async () => {
+			if (installConfig.centralConfig.ampcDosaInfo.isNew) {
+				console.log(
+					chalk.yellow(
+						`The secret '${helpers.amplifyAgentsKeysSecret}' will be created with the same "private_key.pem" and "public_key.pem" that was auto generated to create the Service Account.`
+					)
+				);
+			}
+
+			await helpers.createAmplifyAgentKeysSecret(
+				akamaiAgentValues.namespace.name,
+				helpers.amplifyAgentsKeysSecret,
+				'publicKey',
+				akamaiAgentValues.centralConfig.dosaAccount.publicKey,
+				'privateKey',
+				akamaiAgentValues.centralConfig.dosaAccount.privateKey
+			);
+		});
+		await helpers.createSecret(akamaiAgentValues.namespace.name, helpers.amplifyAgentsCredsSecret, async () => {
+			await createAkamaiCredsSecret(
+				akamaiAgentValues.namespace.name,
+				helpers.amplifyAgentsCredsSecret,
+				akamaiAgentValues.akamaiSecret,
+				akamaiAgentValues.agentKeysSecret
+			);
+		});
+	}
+
+	console.log('Generating the configuration file(s)...');
+	if (installConfig.switches.isDockerInstall) {
+		writeTemplates(ConfigFiles.agentEnvVars, akamaiAgentValues, helpers.akamaiEnvVarTemplate);
+	} else if (installConfig.switches.isHelmInstall) {
+		writeTemplates(ConfigFiles.helmOverride, akamaiAgentValues, helpers.akamaiHelmOverrideTemplate);
+	}
+
+	generateSuccessHelpMsg(installConfig);
+};
+
+const createAkamaiCredsSecret = async (
+	namespace: string,
+	secretName: string,
+	clientID: string,
+	clientSecret: string,
+): Promise<void> => {
+	const { error } = await kubectl.create(
+		'secret',
+		`-n ${namespace} generic ${secretName} \
+		--from-literal=clientID=${clientID} \
+		--from-literal=clientSecret=${clientSecret}`
+	);
+	if (error) {
+		throw Error(error);
+	}
+	console.log(`Created ${secretName} in the ${namespace} namespace.`);
 };
 
 export const AkamaiInstallMethods: InstallationFlowMethods = {
@@ -54,3 +306,4 @@ export const AkamaiInstallMethods: InstallationFlowMethods = {
 	},
 	GatewayDisplay: GatewayTypes.AKAMAI,
 };
+

--- a/src/lib/engage/utils/agents/flows/akamaiSaasAgents.ts
+++ b/src/lib/engage/utils/agents/flows/akamaiSaasAgents.ts
@@ -1,34 +1,321 @@
+import chalk from 'chalk';
+import logger from '../../../../logger.js';
+import { ApiServerClient } from '../../../clients-external/apiserverclient.js';
+import { DefinitionsManager } from '../../../results/DefinitionsManager.js';
 import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, SaaSGatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
-import { AkamaiAgentValues } from '../index.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentResourceKind, AgentTypes, BundleType, CentralAgentConfig, GatewayTypes, GatewayTypeToDataPlane, GenericResource, SaaSGatewayTypes, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList, validateRegex, validateValueRange } from '../../basic-prompts.js';
 import * as helpers from '../index.js';
+import * as crypto from 'crypto';
+import { DataplaneConfig } from './saasAgentsBase.js';
+
+const { log } = logger('engage: install: agents: Akamai');
+
+class AkamaiDataplaneConfig extends DataplaneConfig {
+	baseUrl: string;
+	segmentLength: number;
+	environments: AkamaiGroups[];
+	constructor(baseUrl: string, segmentLength: number, groups: AkamaiGroups[]) {
+		super('Akamai');
+		this.baseUrl = baseUrl;
+		this.segmentLength = segmentLength;
+		this.environments = groups;
+	}
+}
+
+class AkamaiGroups {
+	akamai: string;
+	environment: string;
+
+	constructor(akamai: string, environment: string) {
+		this.akamai = akamai;
+		this.environment = environment;
+	}
+}
+
+class SaasAgentValues {
+	dataplaneConfig: DataplaneConfig;
+	centralConfig: CentralAgentConfig;
+
+	constructor() {
+		this.dataplaneConfig = new DataplaneConfig();
+		this.centralConfig = new CentralAgentConfig();
+	}
+
+	getAccessData() {
+		return '';
+	}
+}
+
+class SaasAkamaiAgentValues extends SaasAgentValues {
+	baseUrl: string;
+	clientId: string;
+	clientSecret: string;
+	segmentLength: number;
+	environments: string[];
+	centralEnvironments: string[];
+
+	constructor() {
+		super();
+		this.baseUrl = '';
+		this.clientId = '';
+		this.clientSecret = '';
+		this.segmentLength = 1;
+		this.environments = [];
+		this.centralEnvironments = [];
+	}
+
+	override getAccessData() {
+		const data = JSON.stringify({
+			clientID: this.clientId,
+			clientSecret: this.clientSecret,
+		});
+
+		return data;
+	}
+}
+
+// AkamaiSaaSPrompts - all Akamai Saas prompts to the user for input
+const SaasPrompts = {
+	configTypeMsg: 'Select the mode of installation',
+	agentNamespace: 'Enter the namespace to use for the Amplify Akamai Agents',
+	enterBaseUrl: 'Enter the Akamai Base URL',
+	enterClientId: 'Enter the Akamai Client ID',
+	enterClientSecret: 'Enter the Akamai Client Secret',
+	enterSegmentLength: 'Enter the Akamai Segment Length',
+	enterEnvironments: 'Enter an Akamai environment',
+	enterMoreEnvironments: 'Do you want to enter another mapping?',
+	selectCentralMappingEnvironment: 'Select an Engage environment to map to the provided Akamai environment',
+	environmentsDescription: 'Configure a mapping of Akamai environment to Engage environment that the agent will use',
+};
 
 export const askBundleType = async (): Promise<BundleType> => {
-	return BundleType.TRACEABILITY as BundleType;
+	return  BundleType.TRACEABILITY as BundleType;
 };
 
-export const ConfigFiles = {
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
+const askConfigType = async (): Promise<AgentConfigTypes> => {
+	return AgentConfigTypes.HOSTED;
 };
 
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
+const askEnvironments = async (centralEnvs: GenericResource[], hostedAgentValues: SaasAkamaiAgentValues, excludeEnvironment?: string): Promise<void> => {
+	// Filter out the already-selected agent installation environment
+	if (excludeEnvironment) {
+		centralEnvs = centralEnvs.filter(env => env.name !== excludeEnvironment);
+	}
+
+	let askEnvs = true;
+	const envs = [];
+	const mappedCentralEnvs = [];
+	console.log(chalk.gray(SaasPrompts.environmentsDescription));
+	while (askEnvs) {
+		const env = (await askInput({
+			msg: SaasPrompts.enterEnvironments,
+			allowEmptyInput: true,
+		})) as string;
+
+		if (envs.length === 0 && (!env || env.toString().trim() === '')) {
+			break;
+		}
+
+		if (env && env.toString().trim() !== '') {
+			envs.push(env);
+		}
+		const centralMappingEnv = await askList({
+			msg: SaasPrompts.selectCentralMappingEnvironment,
+			choices: centralEnvs.map((e) => e.name),
+		});
+
+		if (centralMappingEnv && centralMappingEnv.toString().trim() !== '') {
+			mappedCentralEnvs.push(centralMappingEnv);
+		}
+		centralEnvs = centralEnvs.filter(env => env.name !== centralMappingEnv);
+
+		// Only ask if they want to continue if there are still environments available to map
+		if (centralEnvs.length > 0) {
+			askEnvs = await askList({
+				msg: SaasPrompts.enterMoreEnvironments,
+				default: YesNo.No,
+				choices: YesNoChoices,
+			}) === YesNo.Yes;
+		} else {
+			askEnvs = false;
+		}
+	}
+	hostedAgentValues.environments = envs;
+	hostedAgentValues.centralEnvironments = mappedCentralEnvs;
 };
 
-export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.HOSTED ],
-	})) as AgentConfigTypes;
+//
+// Questions for the configuration of Akamai agents
+//
+const askAkamaiBaseUrl = async (): Promise<string> =>
+	(await askInput({
+		msg: SaasPrompts.enterBaseUrl,
+		validate: validateRegex(
+			helpers.AkamaiRegexPatterns.baseURLRegex,
+			helpers.invalidValueExampleErrMsg('baseURL', 'https://akamai.com'),
+		),
+	})) as string;
+
+const askAkamaiClientId = async (): Promise<string> =>
+	(await askInput({
+		msg: SaasPrompts.enterClientId,
+	})) as string;
+
+const askAkamaiClientSecret = async (): Promise<string> =>
+	(await askInput({
+		msg: SaasPrompts.enterClientSecret,
+	})) as string;
+
+const askAkamaiSegmentLength = async (): Promise<number> =>
+	(await askInput({
+		msg: SaasPrompts.enterSegmentLength,
+		type: 'number',
+		validate: validateValueRange(0),
+	})) as number;
+
+const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<SaasAgentValues> => {
+	console.log('\nCONNECTION TO AKAMAI API GATEWAY:');
+	// DeploymentType
+	let hostedAgentValues: SaasAkamaiAgentValues = new SaasAkamaiAgentValues();
+
+	if (installConfig.gatewayType === SaaSGatewayTypes.AKAMAI) {
+		log('gathering access details for akamai');
+
+		// Akamai connection details
+		hostedAgentValues = new SaasAkamaiAgentValues();
+		hostedAgentValues.baseUrl = await askAkamaiBaseUrl();
+		hostedAgentValues.clientId = await askAkamaiClientId();
+		hostedAgentValues.clientSecret = await askAkamaiClientSecret();
+		hostedAgentValues.segmentLength = await askAkamaiSegmentLength();
+
+		const centralEnvs = await helpers.getCentralEnvironments(installConfig.centralConfig.apiServerClient as ApiServerClient, installConfig.centralConfig.definitionManager as DefinitionsManager);
+		// Pass the already-selected agent installation environment to exclude it from mapping choices
+		const agentInstallEnv = installConfig.centralConfig.ampcEnvInfo?.name;
+		await askEnvironments(centralEnvs!, hostedAgentValues, agentInstallEnv);
+	}
+
+	return hostedAgentValues;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<AkamaiAgentValues> => {
-	const values: AkamaiAgentValues = new AkamaiAgentValues();
-	return values;
+const generateOutput = async (installConfig: AgentInstallConfig): Promise<string> => {
+	return `Install complete of hosted agent for ${installConfig.gatewayType} region`;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const createEncryptedAccessData = async (hostedAgentValues: SaasAkamaiAgentValues, dataplaneRes: GenericResource): Promise<string> => {
+	// grab key from data plane resource
+	const key = dataplaneRes.security?.encryptionKey  || '';
+	const hash = dataplaneRes.security?.encryptionHash || '';
+
+	if (key === '' || hash === '') {
+		throw Error('cannot encrypt access data as the encryption key info was incomplete');
+	}
+
+	const accessData = hostedAgentValues.getAccessData();
+
+	const encData = crypto.publicEncrypt({
+		key: key,
+		padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+		oaepHash: hash,
+	},
+	new Uint8Array(Buffer.from(accessData, 'utf8'))
+	);
+
+	return encData.toString('base64');
+};
+
+const completeInstall = async (installConfig: AgentInstallConfig, apiServerClient?: ApiServerClient, defsManager?: DefinitionsManager): Promise<void> => {
+	/**
+     * Create agent resources
+     */
+	console.log('\n');
+	const akamaiAgentValues = installConfig.gatewayConfig as SaasAkamaiAgentValues;
+
+	// create the environment, if necessary
+	installConfig.centralConfig.environment = installConfig.centralConfig.ampcEnvInfo.isNew
+		? await helpers.createByResourceType(
+			apiServerClient as ApiServerClient,
+			defsManager as DefinitionsManager,
+			installConfig.centralConfig.ampcEnvInfo.name,
+			'Environment',
+			'env',
+			{
+				axwayManaged: installConfig.centralConfig.axwayManaged,
+				production: installConfig.centralConfig.production,
+			}
+		)
+		: installConfig.centralConfig.ampcEnvInfo.name;
+
+	if (installConfig.gatewayType === GatewayTypes.AKAMAI) {
+		const akamaiGroupObjs = (akamaiAgentValues.environments || []).map((env, idx) =>
+			new AkamaiGroups(env, akamaiAgentValues.centralEnvironments[idx])
+		);
+		akamaiAgentValues.dataplaneConfig = new AkamaiDataplaneConfig(
+			akamaiAgentValues.baseUrl,
+			akamaiAgentValues.segmentLength,
+			akamaiGroupObjs
+		);
+	}
+
+	// create the data plane resource
+	const dataplaneRes = await helpers.createNewDataPlaneResource(
+		apiServerClient as ApiServerClient,
+		defsManager as DefinitionsManager,
+		installConfig.centralConfig.environment,
+		GatewayTypeToDataPlane[installConfig.gatewayType],
+		akamaiAgentValues.dataplaneConfig,
+	);
+	// create data plane secret resource
+	try {
+		await helpers.createNewDataPlaneSecretResource(
+			apiServerClient as ApiServerClient,
+			defsManager as DefinitionsManager,
+			installConfig.centralConfig.environment,
+			GatewayTypeToDataPlane[installConfig.gatewayType],
+			dataplaneRes.name,
+			await createEncryptedAccessData(akamaiAgentValues, dataplaneRes),
+		);
+	} catch (error) {
+		log(error);
+		console.log(
+			chalk.redBright('rolling back installation. Please check the credential data before re-running install')
+		);
+
+		if (installConfig.centralConfig.ampcEnvInfo.isNew) {
+			await helpers.deleteByResourceType(
+				apiServerClient as ApiServerClient,
+				defsManager as DefinitionsManager,
+				installConfig.centralConfig.ampcEnvInfo.name,
+				'Environment',
+				'env',
+			);
+		} else {
+			await helpers.deleteByResourceType(
+				apiServerClient as ApiServerClient,
+				defsManager as DefinitionsManager,
+				dataplaneRes.name,
+				'Dataplane',
+				'dp',
+				installConfig.centralConfig.environment,
+			);
+		}
+		return;
+	}
+
+	// create compliance agent resource
+	installConfig.centralConfig.taAgentName = await helpers.createNewAgentResource(
+		apiServerClient as ApiServerClient,
+		defsManager as DefinitionsManager,
+		installConfig.centralConfig.environment,
+		GatewayTypeToDataPlane[installConfig.gatewayType],
+		AgentResourceKind.ca,
+		AgentTypes.ca,
+		installConfig.centralConfig.ampcTeamName,
+		GatewayTypeToDataPlane[installConfig.gatewayType] + ' Compliance Agent',
+		dataplaneRes.name
+	);
+
+	console.log(await generateOutput(installConfig));
 };
 
 export const AkamaiSaaSInstallMethods: InstallationFlowMethods = {
@@ -36,9 +323,9 @@ export const AkamaiSaaSInstallMethods: InstallationFlowMethods = {
 	GetDeploymentType: askConfigType,
 	AskGatewayQuestions: gatewayConnectivity,
 	FinalizeGatewayInstall: completeInstall,
-	ConfigFiles: Object.values(ConfigFiles),
+	ConfigFiles: [],
 	AgentNameMap: {
 		[AgentTypes.ca]: AgentNames.AKAMAI_CA,
 	},
-	GatewayDisplay: SaaSGatewayTypes.AKAMAI,
+	GatewayDisplay: GatewayTypes.AKAMAI,
 };

--- a/src/lib/engage/utils/agents/flows/backstageAgents.ts
+++ b/src/lib/engage/utils/agents/flows/backstageAgents.ts
@@ -1,35 +1,177 @@
-import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
-import { BackstageAgentValues } from '../templates/backstageTemplates.js';
+import { InstallationFlowMethods, svcAccMsg } from '../../../services/install-service.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, PublicDockerRepoBaseUrl } from '../../../types.js';
+import { askInput, askList } from '../../basic-prompts.js';
+import { AuthMode, BackstageAgentValues, backstageDAEnvVarTemplate, UrlScheme } from '../templates/backstageTemplates.js';
 import * as helpers from '../index.js';
+import chalk from 'chalk';
+import { isWindows, writeTemplates } from '../../utils.js';
+
+const daImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.BACKSTAGE_DA}`;
+
+export const defaultLogFiles = '/group-*_instance-*.log';
+
+// ConfigFiles - all the config file that are used in the setup
+export const ConfigFiles = {
+	DAEnvVars: `${helpers.configFiles.DA_ENV_VARS}`,
+	BackstageDABinaryFile: 'discovery_agent',
+	BackstageDAYaml: 'discovery_agent.yml',
+};
+
+const BackstagePrompts = {
+	enterUrlHost: 'Enter the host of the URL for connecting to Backstage',
+	selectUrlScheme: 'Select the scheme of the URL for connecting to Backstage',
+	enterBackendPort: '(Optional) Enter the backend port of the URL for connecting to Backstage',
+	enterUrlPath: '(Optional) Enter the path of the URL for connecting to Backstage',
+
+	selectAuthMode: 'Select the authentication type for connecting to Backstage',
+	enterStaticTokenValue: 'Enter the static token value',
+	enterJwksClientID: 'Enter the ClientID for the JWKS Auth Flow',
+	enterJwksClientSecret: 'Enter the ClientSecret for the JWKS Auth Flow',
+	enterJwksTokenURL: 'Enter TokenURL for the JWKS Auth Flow',
+};
 
 export const askBundleType = async (): Promise<BundleType> => {
-	return BundleType.DISCOVERY as BundleType;
-};
-
-export const ConfigFiles = {
-	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
-};
-
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
+	// Backstage agent has only DA
+	return BundleType.DISCOVERY;
 };
 
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
-	})) as AgentConfigTypes;
+	return AgentConfigTypes.DOCKERIZED;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<BackstageAgentValues> => {
-	const values: BackstageAgentValues = new BackstageAgentValues();
+//
+// Questions for the configuration of Backstage agent
+//
+const askBackstageUrlHost = async (): Promise<string> =>
+	(await askInput({
+		msg: BackstagePrompts.enterUrlHost
+	})) as string;
+
+const askBackstageUrlScheme = async (): Promise<UrlScheme> =>
+	(await askList({
+		msg: BackstagePrompts.selectUrlScheme,
+		choices: [ UrlScheme.HTTP, UrlScheme.HTTPS ],
+	})) as UrlScheme;
+
+const askBackstageUrlBackendPort = async (): Promise<number> =>
+	(await askInput({
+		msg: BackstagePrompts.enterBackendPort,
+		allowEmptyInput: true,
+	})) as number;
+
+const askBackstageUrlPath = async (): Promise<string> =>
+	(await askInput({
+		msg: BackstagePrompts.enterUrlPath,
+		allowEmptyInput: true,
+	})) as string;
+
+const askBackstageAuthMode = async (): Promise<AuthMode> =>
+	(await askList({
+		msg: BackstagePrompts.selectAuthMode,
+		choices: [
+			{ name: 'No auth',
+				value: AuthMode.NoAuth,
+			}, AuthMode.Guest, AuthMode.StaticToken, AuthMode.Jwks ],
+	})) as AuthMode;
+
+const askBackstageAuthStaticToken = async (): Promise<string> =>
+	(await askInput({
+		msg: BackstagePrompts.enterStaticTokenValue,
+	})) as string;
+
+const askBaskstageAuthJwksClientID = async (): Promise<string> =>
+	(await askInput({
+		msg: BackstagePrompts.enterJwksClientID,
+	})) as string;
+
+const askBaskstageAuthJwksClientSecret = async (): Promise<string> =>
+	(await askInput({
+		msg: BackstagePrompts.enterJwksClientSecret,
+	})) as string;
+
+const askBaskstageAuthJwksTokenUrl = async (): Promise<string> =>
+	(await askInput({
+		msg: BackstagePrompts.enterJwksTokenURL,
+	})) as string;
+
+export const gatewayConnectivity = async (): Promise<BackstageAgentValues> => {
+	const backstageAgentValues: BackstageAgentValues = new BackstageAgentValues();
+	console.log('\nCONNECTION TO Backstage:');
+	console.log(
+		chalk.gray(
+			'The discovery agent needs to connect to Backstage to discover API\'s for publishing to Amplify.'
+		)
+	);
+
+	await askPrompts(backstageAgentValues);
+
+	return backstageAgentValues;
+};
+
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	console.log(chalk.yellow(svcAccMsg));
+
+	dockerSuccessMsg(installConfig);
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.BACKSTAGE}`)
+	);
+};
+
+const dockerSuccessMsg = (installConfig: AgentInstallConfig) => {
+	const runDaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runDaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startDaLinuxMsg = '\nStart the Discovery Agent on a Linux based machine';
+	const startDaWinMsg = '\nStart the Discovery Agent on a Windows machine';
+
+	const dockerInfo = `To utilize the agents, pull the latest Docker images and run them using the appropriate supplied environment files, (${helpers.configFiles.DA_ENV_VARS}:`;
+	console.log(chalk.whiteBright(dockerInfo), '\n');
+
+	const daImageVersion = `${daImage}:${installConfig.daVersion}`;
+	console.log(chalk.white('Pull the latest image of the Discovery Agent:'));
+	console.log(chalk.cyan(`docker pull ${daImageVersion}`));
+	console.log(chalk.white(isWindows ? startDaWinMsg : startDaLinuxMsg));
+	console.log(chalk.cyan(isWindows ? runDaWinMsg : runDaLinuxMsg));
+	console.log('\t', chalk.cyan(`-v /data ${daImageVersion}`), '\n');
+};
+
+async function askPrompts(values: BackstageAgentValues) {
+	values.host = await askBackstageUrlHost();
+	values.scheme = await askBackstageUrlScheme();
+	values.backendPort = await askBackstageUrlBackendPort();
+	values.urlPath = await askBackstageUrlPath();
+
+	values.authMode = await askBackstageAuthMode();
+	switch (values.authMode) {
+		case AuthMode.StaticToken: {
+			values.staticTokenValue = await askBackstageAuthStaticToken();
+			break;
+		}
+		case AuthMode.Jwks: {
+			values.jwksClientID = await askBaskstageAuthJwksClientID();
+			values.jwksClientSecret = await askBaskstageAuthJwksClientSecret();
+			values.jwksTokenURL = await askBaskstageAuthJwksTokenUrl();
+			break;
+		}
+	}
+
 	return values;
-};
+}
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	/**
+	 * Create agent resources
+	 */
+	const backstageAgentValues = installConfig.gatewayConfig as BackstageAgentValues;
+
+	// Add final settings
+	backstageAgentValues.centralConfig = installConfig.centralConfig;
+
+	console.log('Generating the configuration file(s)...');
+	writeTemplates(ConfigFiles.DAEnvVars, backstageAgentValues, backstageDAEnvVarTemplate);
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	generateSuccessHelpMsg(installConfig);
 };
 
 export const BackstageInstallMethods: InstallationFlowMethods = {
@@ -40,6 +182,7 @@ export const BackstageInstallMethods: InstallationFlowMethods = {
 	ConfigFiles: Object.values(ConfigFiles),
 	AgentNameMap: {
 		[AgentTypes.da]: AgentNames.BACKSTAGE_DA,
+		[AgentTypes.ta]: AgentNames.BACKSTAGE_DA,
 	},
 	GatewayDisplay: GatewayTypes.BACKSTAGE,
 };

--- a/src/lib/engage/utils/agents/flows/edgeAgents.ts
+++ b/src/lib/engage/utils/agents/flows/edgeAgents.ts
@@ -1,69 +1,514 @@
-import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import chalk from 'chalk';
+import fs from 'fs';
+import { dataService } from '../../../../request.js';
+import { InstallationFlowMethods, localhost, svcAccMsg } from '../../../services/install-service.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, LoggingSource, PublicDockerRepoBaseUrl, PublicRepoUrl, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList, askUsernameAndPassword } from '../../basic-prompts.js';
+import { writeTemplates, isWindows, AgentHelmInfo } from '../../utils.js';
 import { V7AgentValues } from '../index.js';
 import * as helpers from '../index.js';
+import { kubectl } from '../kubectl.js';
+import { amplifyAgentsNs } from './akamaiAgent.js';
+import { Account } from '../../../../../types.js';
+
+const defaultLogFiles = '/group-*_instance-*.log';
+const defaultOTLogFiles = '/group-*_instance-*_traffic*.log';
+export const dockerPrivateKey = '/keys/private_key.pem';
+export const dockerPublicKey = '/keys/public_key.pem';
+
+const daImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.EDGE_DA}`;
+const taImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.EDGE_TA}`;
+
+// ConfigFiles - all the config file that are used in the setup
+export const ConfigFiles = {
+	DAEnvVars: `${helpers.configFiles.DA_ENV_VARS}`,
+	DAHelmOverride: 'da-overrides.yaml',
+	EdgeDABinaryFile: 'discovery_agent',
+	EdgeDAYaml: 'discovery_agent.yml',
+	EdgeTABinaryFile: 'traceability_agent',
+	EdgeTAYaml: 'traceability_agent.yml',
+	TAEnvVars: `${helpers.configFiles.TA_ENV_VARS}`,
+	TAHelmOverride: 'ta-overrides.yaml',
+};
+
+export const prompts = {
+	configTypeMsg: 'Select the mode of installation',
+	askApiGatewayHost: 'Enter the API Gateway hostname',
+	askApiGatewayPort: 'Enter the API Gateway port',
+	askApiManagerHost: 'Enter the API Manager hostname',
+	askApiManagerPort: 'Enter the API Manager port',
+	askLoggingSource: 'What is the source of logging for the traceability agent',
+	askEventsPath: 'Enter the path to the API Gateway event log directory',
+	askOpenTrafficPath: 'Enter the path to the API Gateway open traffic log directory',
+	enterGatewayAgentNs: 'Enter the namespace to use for the Amplify Gateway Agents',
+	enterGatewayManagerMode: 'Do you want to use API Manager with the API Gateway',
+	askIfOrgReplication:
+		'Do you want to replicate your original organization structure for your newly discovered APIs? If yes, make sure the organization names match the team names that are created in Amplify platform',
+};
+
+const downloadV7AgentBundle = async (account: Account, type: BundleType, version: string): Promise<string> => {
+	const fileName
+		= type === BundleType.DISCOVERY ? `discovery_agent-${version}.zip` : `traceability_agent-${version}.zip`;
+	const url
+		= type === BundleType.DISCOVERY
+			? `${BasePaths.V7Agents}/v7_discovery_agent/${version}/discovery_agent-${version}.zip`
+			: `${BasePaths.V7Agents}/v7_traceability_agent/${version}/traceability_agent-${version}.zip`;
+	const service = await dataService({
+		baseUrl: PublicRepoUrl,
+	});
+	try {
+		const { stream } = await service.download(url);
+		await helpers.streamPipeline(stream, fs.createWriteStream(fileName));
+		return fileName;
+	} catch (err: any) {
+		throw new Error(`Failed to download the agent: ${err.message}`);
+	}
+};
+
+const downloadBinary = async (account: Account, bundleType: BundleType, version: string) => {
+	const fileName = await downloadV7AgentBundle(account, bundleType, version);
+	await helpers.unzip(fileName);
+	fs.unlinkSync(fileName);
+};
+
+const downloadBinaries = async (installConfig: AgentInstallConfig) => {
+	const account = installConfig.centralConfig.apiServerClient?.account;
+	if (!account) {
+		throw new Error('Unable to resolve account for DataService call during AWS agent install preprocess');
+	}
+	console.log('Downloading and unpacking binary files...');
+	if (installConfig.switches.isDaEnabled) {
+		await downloadBinary(account, BundleType.DISCOVERY, installConfig.daVersion);
+	}
+	if (installConfig.switches.isTaEnabled) {
+		await downloadBinary(account, BundleType.TRACEABILITY, installConfig.taVersion);
+	}
+	console.log('Downloading and unpacking is complete.');
+};
+
+export const askIsGatewayOnlyMode = async (): Promise<GatewayTypes> => {
+	const mode = await askList({
+		msg: prompts.enterGatewayManagerMode,
+		default: YesNo.Yes,
+		choices: YesNoChoices,
+	});
+	return mode === YesNo.Yes ? GatewayTypes.EDGE_GATEWAY : GatewayTypes.EDGE_GATEWAY_ONLY;
+};
+
+export const askOrganizationReplication = async (): Promise<boolean> => {
+	const mode = await askList({
+		msg: prompts.askIfOrgReplication,
+		default: YesNo.Yes,
+		choices: YesNoChoices,
+	});
+	return mode === YesNo.Yes;
+};
 
 export const askBundleType = async (): Promise<BundleType> => {
 	return (await askList({
-		msg: 'Select the type of agent(s) you want to install',
+		msg: helpers.agentMessages.selectAgentType,
 		choices: [ BundleType.ALL_AGENTS, BundleType.DISCOVERY, BundleType.TRACEABILITY ],
 	})) as BundleType;
 };
 
-export const askIsGatewayOnlyMode = async (): Promise<GatewayTypes> => {
+export const askBundleTypeGWOnly = async (): Promise<BundleType> => {
 	return (await askList({
-		msg: 'Select the gateway mode',
-		choices: [ GatewayTypes.EDGE_GATEWAY, GatewayTypes.EDGE_GATEWAY_ONLY ],
-	})) as GatewayTypes;
-};
-
-export const askOrganizationReplication = async (): Promise<boolean> => {
-	const answer = await askList({
-		msg: 'Would you like to replicate the organization structure?',
-		choices: [ 'Yes', 'No' ],
-	});
-	return answer === 'Yes';
-};
-
-export const ConfigFiles = {
-	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
-};
-
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
+		msg: helpers.agentMessages.selectAgentType,
+		choices: [ BundleType.TRACEABILITY, BundleType.TRACEABILITY_OFFLINE ],
+	})) as BundleType;
 };
 
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
 	return (await askList({
 		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
+		choices: [ AgentConfigTypes.BINARIES, AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM ],
 	})) as AgentConfigTypes;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<V7AgentValues> => {
-	const values: V7AgentValues = new V7AgentValues();
-	return values;
+const askLoggingSource = async (): Promise<boolean> => {
+	console.log(
+		chalk.white('\nThe API Gateway can provide the API traffic either within event logs or open traffic logs.')
+	);
+	return (
+		(await askList({
+			msg: prompts.askLoggingSource,
+			default: LoggingSource.Event,
+			choices: [ LoggingSource.Event, LoggingSource.OpenTraffic ],
+		})) === LoggingSource.OpenTraffic
+	);
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const askEventsPath = async (isOpenTraffic: boolean): Promise<string> => {
+	return (await askInput({
+		msg: isOpenTraffic ? prompts.askOpenTrafficPath : prompts.askEventsPath,
+		defaultValue: isOpenTraffic ? '/apigateway/logs/opentraffic' : '/apigateway/events',
+		type: 'string',
+	})) as string;
+};
+
+const askApiManagerHost = async (): Promise<string> => {
+	return (await askInput({
+		msg: prompts.askApiManagerHost,
+		defaultValue: localhost,
+	})) as string;
+};
+
+const askApiManagerPort = async (): Promise<string> => {
+	return (await askInput({
+		msg: prompts.askApiManagerPort,
+		defaultValue: 8075,
+		type: 'number',
+	})) as string;
+};
+
+const askApiGatewayHost = async (): Promise<string> => {
+	return (await askInput({
+		msg: prompts.askApiGatewayHost,
+		defaultValue: localhost,
+	})) as string;
+};
+
+const askApiGatewayPort = async (): Promise<string> => {
+	return (await askInput({
+		msg: prompts.askApiGatewayPort,
+		defaultValue: 8090,
+		type: 'number',
+	})) as string;
+};
+
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<V7AgentValues> => {
+	const v7AgentValues: V7AgentValues = new V7AgentValues();
+
+	if (installConfig.switches.isHelmInstall) {
+		const { error } = await kubectl.isInstalled();
+		if (error) {
+			throw new Error(
+				`Kubectl is required to fill out the following prompts. It appears to be missing or misconfigured.\n${error}`
+			);
+		}
+	}
+
+	if (!installConfig.switches.isGatewayOnly || installConfig.switches.isDaEnabled) {
+		console.log('\nCONNECTION TO API MANAGER:');
+		console.log(
+			chalk.gray(
+				'The agents need to connect to the Axway API Manager to discover APIs for publishing to Amplify.\n'
+					+ 'Use the credentials of an API Manager Administrator user or an Organization Administrator user.'
+			)
+		);
+
+		if (installConfig.switches.isHelmInstall) {
+			console.log(chalk.white('Please use the name of the API Manager Service as hostname.'));
+		}
+
+		v7AgentValues.apiManagerHost = await askApiManagerHost();
+		v7AgentValues.apiManagerPort = await askApiManagerPort();
+
+		const apimCreds = await askUsernameAndPassword('the API Manager', 'apiadmin');
+		v7AgentValues.apiManagerAuthUser = apimCreds.username;
+		v7AgentValues.apiManagerAuthPass = apimCreds.password;
+	}
+
+	if (installConfig.switches.isTaEnabled) {
+		v7AgentValues.isOpenTraffic = await askLoggingSource();
+
+		if (!v7AgentValues.isOpenTraffic && installConfig.bundleType !== BundleType.TRACEABILITY_OFFLINE) {
+			console.log('\nCONNECTION TO API GATEWAY:');
+			console.log(
+				chalk.gray(
+					'The traceability agent needs to connect to Axway API Gateway.\n'
+					+ 'Use the credentials of an Operator user.'
+				)
+			);
+
+			if (installConfig.switches.isHelmInstall) {
+				console.log(chalk.white('Please use the name of the API Gateway Service as hostname.'));
+			}
+
+			v7AgentValues.apiGatewayHost = await askApiGatewayHost();
+			v7AgentValues.apiGatewayPort = await askApiGatewayPort();
+
+			const apigwCreds = await askUsernameAndPassword('the API Gateway', 'admin');
+			v7AgentValues.apiGatewayAuthUser = apigwCreds.username;
+			v7AgentValues.apiGatewayAuthPass = apigwCreds.password;
+		}
+
+		if (installConfig.switches.isBinaryInstall || installConfig.switches.isDockerInstall) {
+			const eventLogPaths = await askEventsPath(v7AgentValues.isOpenTraffic);
+			const trimmedDir = eventLogPaths.trim();
+			v7AgentValues.eventLogPath = eventLogPaths
+				? trimmedDir[trimmedDir.length - 1] === '/'
+					? `${trimmedDir.slice(0, -1)}`
+					: `${trimmedDir}`
+				: '';
+			v7AgentValues.eventLogPathTemplate = installConfig.switches.isBinaryInstall
+				? `${v7AgentValues.eventLogPath}${v7AgentValues.isOpenTraffic ? defaultOTLogFiles : defaultLogFiles}`
+				: '';
+		}
+	}
+
+	if (installConfig.switches.isHelmInstall) {
+		v7AgentValues.namespace = await helpers.askNamespace(prompts.enterGatewayAgentNs, amplifyAgentsNs);
+	}
+
+	return v7AgentValues;
+};
+
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	const v7AgentValues = installConfig.gatewayConfig as V7AgentValues;
+	const configType = installConfig.deploymentType;
+	const trimmedDir = v7AgentValues.eventLogPath?.trim();
+	const verifiedEventsPath = v7AgentValues.eventLogPath
+		? trimmedDir[trimmedDir.length - 1] === '/'
+			? `${trimmedDir.slice(0, -1)}:/events`
+			: `${trimmedDir}:/events`
+		: '';
+
+	if (installConfig.centralConfig.ampcDosaInfo.isNew && !installConfig.switches.isHelmInstall) {
+		console.log(chalk.yellow(svcAccMsg));
+	}
+
+	if (configType === AgentConfigTypes.BINARIES) {
+		binarySuccessMsg(
+			installConfig.centralConfig.ampcDosaInfo.isNew,
+			installConfig.switches.isDaEnabled,
+			installConfig.switches.isTaEnabled
+		);
+	} else if (configType === AgentConfigTypes.DOCKERIZED) {
+		dockerSuccessMsg(installConfig, verifiedEventsPath);
+	} else if (installConfig.switches.isHelmInstall) {
+		helmSuccessMsg(
+			v7AgentValues.namespace.name,
+			installConfig.switches.isDaEnabled,
+			installConfig.switches.isTaEnabled
+		);
+	}
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.V7}`)
+	);
+};
+
+export const installPreprocess = async (installConfig: AgentInstallConfig): Promise<AgentInstallConfig> => {
+	// Ask for key paths if HELM, and dosa NOT new
+	if (installConfig.deploymentType === AgentConfigTypes.HELM && !installConfig.centralConfig.ampcDosaInfo.isNew) {
+		[ installConfig.centralConfig.dosaAccount.publicKey, installConfig.centralConfig.dosaAccount.privateKey ]
+			= await helpers.askPublicAndPrivateKeysPath();
+	}
+
+	// attempt to download the binaries prior to creating resources
+	if (installConfig.switches.isBinaryInstall) {
+		await downloadBinaries(installConfig);
+	}
+
+	return installConfig;
+};
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	/**
+	 * Create agent resources
+	 */
+	const v7AgentValues = installConfig.gatewayConfig as V7AgentValues;
+
+	// Add final settings to v7AgentsValues
+	v7AgentValues.centralConfig = installConfig.centralConfig;
+	v7AgentValues.traceabilityConfig = installConfig.traceabilityConfig;
+	v7AgentValues.isGatewayOnly = installConfig.switches.isGatewayOnly;
+	v7AgentValues.daVersion = installConfig.daVersion;
+	v7AgentValues.taVersion = installConfig.taVersion;
+
+	if (installConfig.switches.isHelmInstall) {
+		if (v7AgentValues.namespace.isNew) {
+			await helpers.createNamespace(v7AgentValues.namespace.name);
+		}
+		await helpers.createSecret(v7AgentValues.namespace.name, helpers.amplifyAgentsKeysSecret, async () => {
+			if (installConfig.centralConfig.ampcDosaInfo.isNew) {
+				console.log(
+					chalk.yellow(
+						`The secret '${helpers.amplifyAgentsKeysSecret}' will be created with the same "private_key.pem" and "public_key.pem" that was auto generated to create the Service Account.`
+					)
+				);
+			}
+
+			await helpers.createAmplifyAgentKeysSecret(
+				v7AgentValues.namespace.name,
+				helpers.amplifyAgentsKeysSecret,
+				'public_key',
+				v7AgentValues.centralConfig.dosaAccount.publicKey,
+				'private_key',
+				v7AgentValues.centralConfig.dosaAccount.privateKey
+			);
+		});
+		await helpers.createSecret(v7AgentValues.namespace.name, helpers.amplifyAgentsCredsSecret, async () => {
+			await helpers.createGatewayAgentCredsSecret(
+				v7AgentValues.namespace.name,
+				helpers.amplifyAgentsCredsSecret,
+				v7AgentValues.apiManagerAuthUser,
+				v7AgentValues.apiManagerAuthPass,
+				v7AgentValues.apiGatewayAuthUser,
+				v7AgentValues.apiGatewayAuthPass
+			);
+		});
+	}
+
+	console.log('Generating the configuration file(s)...');
+
+	if (installConfig.switches.isHelmInstall) {
+		if (installConfig.switches.isDaEnabled) {
+			writeTemplates(ConfigFiles.DAHelmOverride, v7AgentValues, helpers.v7DAHelmOverrideTemplate);
+		}
+
+		if (installConfig.switches.isTaEnabled) {
+			writeTemplates(ConfigFiles.TAHelmOverride, v7AgentValues, helpers.v7TAHelmOverrideTemplate);
+		}
+	} else {
+		if (installConfig.switches.isDaEnabled) {
+			writeTemplates(ConfigFiles.DAEnvVars, v7AgentValues, helpers.v7DAEnvVarTemplate);
+		}
+
+		if (installConfig.switches.isTaEnabled) {
+			writeTemplates(ConfigFiles.TAEnvVars, v7AgentValues, helpers.v7TAEnvVarTemplate);
+		}
+	}
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	generateSuccessHelpMsg(installConfig);
+};
+
+const dockerSuccessMsg = (installConfig: AgentInstallConfig, eventLogPath: string) => {
+	let dockerInfo;
+	const runDaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runDaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const runTaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runTaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startDaLinuxMsg = '\nStart the Discovery Agent on a Linux based machine';
+	const startDaWinMsg = '\nStart the Discovery Agent on a Windows machine';
+	const startTaLinuxMsg = '\nStart the Traceability Agent on a Linux based machine';
+	const startTaWinMsg = '\nStart the Traceability Agent on a Windows machine';
+
+	if (installConfig.switches.isDaEnabled && installConfig.switches.isTaEnabled) {
+		dockerInfo = `To utilize the agents, pull the latest Docker images and run them using the appropriate supplied environment files, (${helpers.configFiles.DA_ENV_VARS} & ${helpers.configFiles.TA_ENV_VARS}):`;
+	} else if (installConfig.switches.isDaEnabled) {
+		dockerInfo = `To utilize the discovery agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.DA_ENV_VARS}):`;
+	} else {
+		dockerInfo = `To utilize the traceability agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.TA_ENV_VARS}):`;
+	}
+	console.log(chalk.whiteBright(dockerInfo), '\n');
+
+	if (installConfig.switches.isDaEnabled) {
+		const daImageVersion = `${daImage}:${installConfig.daVersion}`;
+		console.log(chalk.white('Pull the latest image of the Discovery Agent:'));
+		console.log(chalk.cyan(`docker pull ${daImageVersion}`));
+		console.log(chalk.white(isWindows ? startDaWinMsg : startDaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runDaWinMsg : runDaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${daImageVersion}`));
+	}
+	if (installConfig.switches.isTaEnabled) {
+		const taImageVersion = `${taImage}:${installConfig.taVersion}`;
+		console.log(chalk.white('Pull the latest image of the Traceability Agent:'));
+		console.log(chalk.cyan(`docker pull ${taImageVersion}`));
+		console.log(chalk.white(isWindows ? startTaWinMsg : startTaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runTaWinMsg : runTaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v ${eventLogPath} -v /data ${taImageVersion}`));
+	}
+};
+
+const binarySuccessMsg = (isNewDosa: boolean, isDaEnabled: boolean, isTaEnabled: boolean) => {
+	const daFiles = [ ConfigFiles.DAEnvVars, ConfigFiles.EdgeDABinaryFile, ConfigFiles.EdgeDAYaml ];
+	const taFiles = [ ConfigFiles.TAEnvVars, ConfigFiles.EdgeTABinaryFile, ConfigFiles.EdgeTAYaml ];
+	const keys = [ 'private_key.pem', 'public_key.pem' ];
+
+	let files: string[] = [];
+	if (isNewDosa) {
+		files = files.concat(keys);
+	}
+	if (isDaEnabled) {
+		files = files.concat(daFiles);
+	}
+	if (isTaEnabled) {
+		files = files.concat(taFiles);
+	}
+	const agents = isDaEnabled && isTaEnabled ? 'agents' : 'agent';
+
+	console.log(chalk.whiteBright('Please copy following files from current folder to API Gateway machine:'));
+	console.log(chalk.cyan(files.join('\n')));
+	console.log(chalk.whiteBright('for example'), chalk.cyan(`scp ${files.join(' ')} root@host:~/some_folder/`));
+
+	console.log(chalk.whiteBright(`\nTo start the ${agents}:`));
+	if (isDaEnabled) {
+		console.log(chalk.cyan(`./discovery_agent --envFile ./${helpers.configFiles.DA_ENV_VARS}`));
+	}
+	if (isTaEnabled) {
+		console.log(chalk.cyan(`./traceability_agent --envFile ./${helpers.configFiles.TA_ENV_VARS}`));
+	}
+};
+
+const helmSuccessMsg = (namespace: string, isDaEnabled: boolean, isTaEnabled: boolean) => {
+	const imagePullOverrides = '--set image.pullSecret=<image-pull-secret-name>';
+	const agentHelmInfo = new Set<AgentHelmInfo>();
+	if (isDaEnabled) {
+		console.log(
+			chalk.white(`Discovery Agent override file has been placed at ${process.cwd()}/${ConfigFiles.DAHelmOverride}`)
+		);
+		agentHelmInfo.add({
+			helmReleaseName: 'v7-discovery',
+			helmChartName: 'axway/v7-discovery',
+			overrideFileName: ConfigFiles.DAHelmOverride,
+			imageSecretOverrides: imagePullOverrides
+		});
+	}
+	if (isTaEnabled) {
+		console.log(
+			chalk.white(`Traceability Agent override file has been placed at ${process.cwd()}/${ConfigFiles.TAHelmOverride}`)
+		);
+		agentHelmInfo.add({
+			helmReleaseName: 'v7-traceability',
+			helmChartName: 'axway/v7-traceability',
+			overrideFileName: ConfigFiles.TAHelmOverride,
+			imageSecretOverrides: imagePullOverrides
+		});
+	}
+
+	helmImageSecretInfo(namespace);
+	helmInstallInfo(
+		'Edge',
+		namespace,
+		agentHelmInfo,
+	);
+};
+
+const edgeAgentNameMap = {
+	[AgentTypes.da]: AgentNames.EDGE_DA,
+	[AgentTypes.ta]: AgentNames.EDGE_TA,
 };
 
 export const EdgeInstallMethods: InstallationFlowMethods = {
 	GetBundleType: askBundleType,
 	GetDeploymentType: askConfigType,
 	AskGatewayQuestions: gatewayConnectivity,
+	InstallPreprocess: installPreprocess,
 	FinalizeGatewayInstall: completeInstall,
 	ConfigFiles: Object.values(ConfigFiles),
-	AgentNameMap: {
-		[AgentTypes.da]: AgentNames.EDGE_DA,
-		[AgentTypes.ta]: AgentNames.EDGE_TA,
-	},
+	AgentNameMap: edgeAgentNameMap,
 	GatewayDisplay: GatewayTypes.EDGE_GATEWAY,
 };
 
 export const EdgeGWOnlyInstallMethods: InstallationFlowMethods = {
-	...EdgeInstallMethods,
-	GatewayDisplay: GatewayTypes.EDGE_GATEWAY_ONLY,
+	GetBundleType: askBundleTypeGWOnly,
+	GetDeploymentType: askConfigType,
+	AskGatewayQuestions: gatewayConnectivity,
+	InstallPreprocess: installPreprocess,
+	FinalizeGatewayInstall: completeInstall,
+	ConfigFiles: Object.values(ConfigFiles),
+	AgentNameMap: edgeAgentNameMap,
+	GatewayDisplay: GatewayTypes.EDGE_GATEWAY,
 };
+function helmImageSecretInfo(namespace: string) {
+	throw new Error('Function not implemented.');
+}
+
+function helmInstallInfo(arg0: string, namespace: string, agentHelmInfo: Set<AgentHelmInfo>) {
+	throw new Error('Function not implemented.');
+}
+

--- a/src/lib/engage/utils/agents/flows/gitHubSaasAgents.ts
+++ b/src/lib/engage/utils/agents/flows/gitHubSaasAgents.ts
@@ -1,32 +1,365 @@
+import chalk from 'chalk';
+import logger from '../../../../logger.js';
+import { ApiServerClient } from '../../../clients-external/apiserverclient.js';
+import { DefinitionsManager } from '../../../results/DefinitionsManager.js';
 import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, SaaSGatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentResourceKind, AgentTypes, BundleType, CentralAgentConfig, GatewayTypeToDataPlane, GenericResource, SaaSGatewayTypes, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList, InputValidation, validateRegex } from '../../basic-prompts.js';
 import * as helpers from '../index.js';
+import * as crypto from 'crypto';
+import { DataplaneConfig } from './saasAgentsBase.js';
+
+const { log } = logger('engage: install: agents: saas');
+
+class GitHubDataplaneConfig extends DataplaneConfig {
+	name: string;
+	ownerName: string;
+	filter: GitHubFilterConfig;
+
+	constructor(name: string, ownerName: string, filter: GitHubFilterConfig) {
+		super('GitHub');
+		this.name = name;
+		this.ownerName = ownerName;
+		this.filter = filter;
+	}
+}
+
+class GitHubFilterConfig {
+	paths: string[];
+	branch: string;
+	pattern: string[];
+
+	constructor(paths: string[], branch: string, pattern: string[]) {
+		this.paths = paths;
+		this.branch = branch;
+		this.pattern = pattern;
+	}
+}
+
+class SaasAgentValues {
+	frequencyDA: string;
+	queueDA: boolean;
+	frequencyTA: string;
+	dataplaneConfig: DataplaneConfig;
+	centralConfig: CentralAgentConfig;
+	repositoryOwner: string;
+	repositoryName: string;
+	repositoryBranch: string;
+	filePaths: string[];
+	filePatterns: string[];
+
+	constructor() {
+		this.frequencyDA = '';
+		this.queueDA = false;
+		this.frequencyTA = '';
+		this.dataplaneConfig = new DataplaneConfig();
+		this.centralConfig = new CentralAgentConfig();
+		this.repositoryOwner = '';
+		this.repositoryName = '';
+		this.repositoryBranch = '';
+		this.filePaths = [];
+		this.filePatterns = [];
+	}
+}
+
+class SaasGitHubAgentValues extends SaasAgentValues {
+	accessToken: string;
+
+	constructor() {
+		super();
+		this.accessToken = '';
+	}
+
+	getAccessData() {
+		const data = JSON.stringify({
+			accessToken: this.accessToken
+		});
+
+		return data;
+	}
+}
+
+// ConfigFiles - all the config file that are used in the setup
+const ConfigFiles = {};
+
+// GitHub SaaSPrompts - all GitHub Saas prompts to the user for input
+const SaasPrompts = {
+	ACCESS_TOKEN: 'Enter the GitHub Access Token the agent will use',
+	REPOSITORY_OWNER: 'Enter the GitHub Repository Owner the agent will use',
+	REPOSITORY_NAME: 'Enter the Repository Name the agent will use',
+	REPOSITORY_BRANCH: 'Enter the Repository Branch the agent will use',
+	FILE_PATHS: 'Enter a File Path within the repository that the agent will use',
+	FILE_PATTERNS: 'Enter a File Pattern that the agent will use (Optional)',
+	DA_FREQUENCY: 'How often should the discovery run, leave blank for integrating in CI/CD process',
+	QUEUE: 'Do you want to discover immediately after installation',
+	ENTER_MORE_PATHS: 'Do you want to enter another file path ?',
+	ENTER_MORE_PATTERNS: 'Do you want to enter another file pattern ?',
+};
 
 export const askBundleType = async (): Promise<BundleType> => {
-	return BundleType.DISCOVERY as BundleType;
+	// GitHub agent has only DA
+	return BundleType.DISCOVERY;
 };
 
-export const ConfigFiles = {
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
+const askConfigType = async (): Promise<AgentConfigTypes> => {
+	return AgentConfigTypes.HOSTED;
 };
 
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
+const askForGitHubCredentials = async (hostedAgentValues: SaasGitHubAgentValues): Promise<SaasAgentValues> => {
+	log('gathering access details for GitHub');
+
+	hostedAgentValues.accessToken = (await askInput({
+		msg: SaasPrompts.ACCESS_TOKEN,
+		defaultValue: hostedAgentValues.accessToken !== '' ? hostedAgentValues.accessToken : undefined,
+		validate: validateRegex(
+			helpers.GitHubRegexPatterns.gitHubAccessTokenRegex,
+			helpers.invalidValueExampleErrMsg('AccessToken', 'ghp_testTokentestTokentestTokentestToken')
+		),
+	})) as string;
+
+	return hostedAgentValues;
 };
 
-export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.HOSTED ],
-	})) as AgentConfigTypes;
+const validateFrequency = (): InputValidation => (input: string | number) => {
+	const val = validateRegex(
+		helpers.frequencyRegex,
+		helpers.invalidValueExampleErrMsg('frequency', '3d5h12m'),
+	)(input);
+	if (typeof val === 'string') {
+		return val;
+	}
+	const r = input.toString().match(/^(\d*)m/);
+	if (r) {
+		// only minutes
+		const mins = r[1];
+		if (parseInt(mins as string, 10) < 30) {
+			return 'Minimum frequency is 30m';
+		}
+	}
+	return true;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<object> => {
-	return {};
+const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<SaasAgentValues> => {
+	console.log('\nCONNECTION TO GitHub API GATEWAY:');
+	console.log(
+		chalk.gray('The Discovery Agent needs to connect to the GitHub API Gateway to discover API\'s for publishing to Amplify Engage')
+	);
+
+	// DeploymentType
+	let hostedAgentValues: SaasAgentValues = new SaasAgentValues();
+
+	if (installConfig.gatewayType === SaaSGatewayTypes.GITHUB) {
+		// GitHub connection details
+		hostedAgentValues = new SaasGitHubAgentValues();
+		hostedAgentValues = await askForGitHubCredentials(hostedAgentValues as SaasGitHubAgentValues);
+	}
+
+	// Ask to queue discovery now
+	log('getting the frequency and if the agent should run now');
+	console.log(
+		chalk.gray('\n00d00h00m format, where 30m = 30 minutes, 1h = 1 hour, 7d = 7 days, and 7d1h30m = 7 days 1 hour and 30 minutes. Minimum of 30m.')
+	);
+	hostedAgentValues.frequencyDA = await askInput({
+		msg: SaasPrompts.DA_FREQUENCY,
+		validate: validateFrequency(),
+		allowEmptyInput: true,
+	}) as string;
+
+	hostedAgentValues.queueDA = await askList({
+		msg: SaasPrompts.QUEUE,
+		default: YesNo.No,
+		choices: YesNoChoices,
+	}) as YesNo === YesNo.Yes;
+
+	// get repository owner
+	hostedAgentValues.repositoryOwner = (await askInput({
+		msg: SaasPrompts.REPOSITORY_OWNER,
+		defaultValue: hostedAgentValues.repositoryOwner !== '' ? hostedAgentValues.repositoryOwner : undefined,
+		validate: validateRegex(
+			helpers.GitHubRegexPatterns.gitHubRepositoryOwnerRegex,
+			helpers.invalidValueExampleErrMsg('Repository Owner', 'axway-github-owner')
+		),
+	})) as string;
+
+	// get repository name
+	hostedAgentValues.repositoryName = (await askInput({
+		msg: SaasPrompts.REPOSITORY_NAME,
+		defaultValue: hostedAgentValues.repositoryName !== '' ? hostedAgentValues.repositoryName : undefined,
+		validate: validateRegex(
+			helpers.GitHubRegexPatterns.gitHubRepositoryNameRegex,
+			helpers.invalidValueExampleErrMsg('Repository Name', 'axway-github-repo-name')
+		),
+	})) as string;
+
+	// get repository branch
+	hostedAgentValues.repositoryBranch = (await askInput({
+		msg: SaasPrompts.REPOSITORY_BRANCH,
+		defaultValue: hostedAgentValues.repositoryBranch !== '' ? hostedAgentValues.repositoryBranch : undefined
+	})) as string;
+
+	// get File Paths
+
+	let askFilePaths = true;
+	console.log(chalk.gray('An array of paths within the repository that the agent will gather files for looking for specs'));
+	while (askFilePaths) {
+		const path = (await askInput({
+			msg: SaasPrompts.FILE_PATHS,
+			allowEmptyInput: false,
+			validate: validateRegex(
+				helpers.GitHubRegexPatterns.gitHubFilePathRegex,
+				helpers.invalidValueExampleErrMsg('File Path', '/apis')
+			),
+		})) as string;
+
+		hostedAgentValues.filePaths.push(path);
+
+		askFilePaths = await askList({
+			msg: SaasPrompts.ENTER_MORE_PATHS,
+			default: YesNo.No,
+			choices: YesNoChoices,
+		}) === YesNo.Yes;
+	}
+
+	// get File Patterns
+
+	let askFilePatterns = true;
+	console.log(chalk.gray('An array of regular expressions that a file name must match to be discovered'));
+	while (askFilePatterns) {
+		const pattern = (await askInput({
+			msg: SaasPrompts.FILE_PATTERNS,
+			allowEmptyInput: true,
+		})) as string;
+
+		if (pattern.trim() !== '') {
+
+			hostedAgentValues.filePatterns.push(pattern);
+
+			askFilePatterns = await askList({
+				msg: SaasPrompts.ENTER_MORE_PATTERNS,
+				default: YesNo.No,
+				choices: YesNoChoices,
+			}) === YesNo.Yes;
+		} else {
+			askFilePatterns = false;
+		}
+	}
+
+	return hostedAgentValues;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const generateOutput = async (installConfig: AgentInstallConfig): Promise<string> => {
+	return `Install complete of hosted agent for ${installConfig.gatewayType} region`;
+};
+
+const createEncryptedAccessData = async (hostedAgentValues: SaasGitHubAgentValues, dataplaneRes: GenericResource): Promise<string> => {
+	// grab key from data plane resource
+	const key = dataplaneRes.security?.encryptionKey  || '';
+	const hash = dataplaneRes.security?.encryptionHash || '';
+
+	if (key === '' || hash === '') {
+		throw Error('cannot encrypt access data as the encryption key info was incomplete');
+	}
+	console.log(hostedAgentValues.getAccessData());
+	const encData = crypto.publicEncrypt({
+		key: key,
+		padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+		oaepHash: hash,
+	},
+	Buffer.from(hostedAgentValues.getAccessData())
+	);
+
+	return encData.toString('base64');
+};
+
+const completeInstall = async (installConfig: AgentInstallConfig, apiServerClient?: ApiServerClient, defsManager?: DefinitionsManager): Promise<void> => {
+	/**
+	 * Create agent resources
+	 */
+	console.log('\n');
+	const gitHubAgentValues = installConfig.gatewayConfig as SaasGitHubAgentValues;
+
+	// create the environment, if necessary
+	installConfig.centralConfig.environment = installConfig.centralConfig.ampcEnvInfo.isNew
+		? await helpers.createByResourceType(
+			apiServerClient as ApiServerClient,
+			defsManager as DefinitionsManager,
+			installConfig.centralConfig.ampcEnvInfo.name,
+			'Environment',
+			'env',
+			{
+				axwayManaged: installConfig.centralConfig.axwayManaged,
+				production: installConfig.centralConfig.production,
+			}
+		)
+		: installConfig.centralConfig.ampcEnvInfo.name;
+
+	if (installConfig.gatewayType === SaaSGatewayTypes.GITHUB) {
+		gitHubAgentValues.dataplaneConfig
+			= new GitHubDataplaneConfig((gitHubAgentValues as SaasGitHubAgentValues).repositoryName,
+				(gitHubAgentValues as SaasGitHubAgentValues).repositoryOwner, new GitHubFilterConfig((gitHubAgentValues as SaasGitHubAgentValues).filePaths,
+					(gitHubAgentValues as SaasGitHubAgentValues).repositoryBranch, (gitHubAgentValues as SaasGitHubAgentValues).filePatterns));
+	}
+
+	// create the data plane resource
+	const dataplaneRes = await helpers.createNewDataPlaneResource(
+		apiServerClient as ApiServerClient,
+		defsManager as DefinitionsManager,
+		installConfig.centralConfig.environment,
+		GatewayTypeToDataPlane[installConfig.gatewayType],
+		gitHubAgentValues.dataplaneConfig,
+	);
+	// create data plane secret resource
+	try {
+		await helpers.createNewDataPlaneSecretResource(
+			apiServerClient as ApiServerClient,
+			defsManager as DefinitionsManager,
+			installConfig.centralConfig.environment,
+			GatewayTypeToDataPlane[installConfig.gatewayType],
+			dataplaneRes.name,
+			await createEncryptedAccessData(gitHubAgentValues, dataplaneRes),
+		);
+	} catch (error) {
+		console.log(
+			chalk.redBright('rolling back installation. Please check the credential data before re-running install')
+		);
+
+		if (installConfig.centralConfig.ampcEnvInfo.isNew) {
+			await helpers.deleteByResourceType(
+				apiServerClient as ApiServerClient,
+				defsManager as DefinitionsManager,
+				installConfig.centralConfig.ampcEnvInfo.name,
+				'Environment',
+				'env',
+			);
+		} else {
+			await helpers.deleteByResourceType(
+				apiServerClient as ApiServerClient,
+				defsManager as DefinitionsManager,
+				dataplaneRes.name,
+				'Dataplane',
+				'dp',
+				installConfig.centralConfig.environment,
+			);
+		}
+		return;
+	}
+
+	// create discovery agent resource
+	installConfig.centralConfig.daAgentName = await helpers.createNewAgentResource(
+		apiServerClient as ApiServerClient,
+		defsManager as DefinitionsManager,
+		installConfig.centralConfig.environment,
+		GatewayTypeToDataPlane[installConfig.gatewayType as SaaSGatewayTypes],
+		AgentResourceKind.da,
+		AgentTypes.da,
+		installConfig.centralConfig.ampcTeamName,
+		GatewayTypeToDataPlane[installConfig.gatewayType as SaaSGatewayTypes] + ' Discovery Agent',
+		dataplaneRes.name,
+		gitHubAgentValues.frequencyDA,
+		gitHubAgentValues.queueDA,
+	);
+
+	console.log(await generateOutput(installConfig));
 };
 
 export const GitHubSaaSInstallMethods: InstallationFlowMethods = {
@@ -34,7 +367,7 @@ export const GitHubSaaSInstallMethods: InstallationFlowMethods = {
 	GetDeploymentType: askConfigType,
 	AskGatewayQuestions: gatewayConnectivity,
 	FinalizeGatewayInstall: completeInstall,
-	ConfigFiles: Object.values(ConfigFiles),
+	ConfigFiles: [],
 	AgentNameMap: {
 		[AgentTypes.da]: AgentNames.GITHUB_DA,
 	},

--- a/src/lib/engage/utils/agents/flows/gitLabAgents.ts
+++ b/src/lib/engage/utils/agents/flows/gitLabAgents.ts
@@ -1,45 +1,202 @@
+import chalk from 'chalk';
 import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, PublicDockerRepoBaseUrl, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList, validateRegex } from '../../basic-prompts.js';
+import { isWindows, writeTemplates } from '../../utils.js';
 import { GitLabAgentValues } from '../index.js';
 import * as helpers from '../index.js';
 
-export const askBundleType = async (): Promise<BundleType> => {
-	return BundleType.DISCOVERY as BundleType;
-};
+const daImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.GITLAB_DA}`;
 
+// ConfigFiles - all the config file that are used in the setup
 export const ConfigFiles = {
-	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
+	DAEnvVars: `${helpers.configFiles.DA_ENV_VARS}`,
 };
 
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
+export const gitLabPrompts = {
+	ACCESS_TOKEN: 'Enter the GitLab Access Token the agent will use',
+	BASE_URL: 'Enter the GitLab base URL that the agent will use',
+	REPOSITORY_ID: 'Enter the GitLab Repository ID the agent will use',
+	REPOSITORY_BRANCH: 'Enter the Repository Branch the agent will use',
+	PATHS: 'Enter a Path within the repository that the agent will use',
+	FILTERS: 'Enter a filter that the agent will use (Optional)',
+	DA_FREQUENCY: 'How often should the discovery run, leave blank for integrating in CI/CD process',
+	QUEUE: 'Do you want to discover immediately after installation',
+	ENTER_MORE_PATHS: 'Do you want to enter another path ?',
+	ENTER_MORE_FILTERS: 'Do you want to enter another filter ?',
+};
+
+export const askBundleType = async (): Promise<BundleType> => {
+	return BundleType.DISCOVERY;
 };
 
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
-	})) as AgentConfigTypes;
+	return AgentConfigTypes.DOCKERIZED;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<GitLabAgentValues> => {
-	const values: GitLabAgentValues = new GitLabAgentValues();
-	return values;
+// Questions for the gitLab configuration
+const askForGitLabToken = async (): Promise<string> =>
+	(await askInput({
+		msg: gitLabPrompts.ACCESS_TOKEN,
+		validate: validateRegex(
+			helpers.GitLabRegexPatterns.gitLabAccessTokenRegex,
+			helpers.invalidValueExampleErrMsg('AccessToken', 'mockToken')
+		),
+	})) as string;
+
+const askForGitLabBaseURL = async (): Promise<string> =>
+	(await askInput({
+		msg: gitLabPrompts.BASE_URL,
+		validate: validateRegex(
+			helpers.GitLabRegexPatterns.gitLabBaseURLRegex,
+			helpers.invalidValueExampleErrMsg('BaseURL', 'https://www.testdomain.com')
+		),
+	})) as string;
+
+const askForGitLabRepositoryID = async (): Promise<string> =>
+	(await askInput({
+		msg: gitLabPrompts.REPOSITORY_ID,
+		validate: validateRegex(
+			helpers.GitLabRegexPatterns.gitHubRepositoryIDRegex,
+			helpers.invalidValueExampleErrMsg('RepositoryID', '12312')
+		),
+	})) as string;
+
+const askForGitLabRepositoryBranch = async (): Promise<string> =>
+	(await askInput({
+		msg: gitLabPrompts.REPOSITORY_BRANCH
+	})) as string;
+
+const askForGitLabPaths = async (): Promise<string[]> => {
+	let askPaths = true;
+	const paths = [];
+	console.log(chalk.gray('An array of paths within the repository that the agent will gather files for looking for specs'));
+	while (askPaths) {
+		const path = (await askInput({
+			msg: gitLabPrompts.PATHS,
+			allowEmptyInput: false,
+			validate: validateRegex(
+				helpers.GitLabRegexPatterns.gitLabPathRegex,
+				helpers.invalidValueExampleErrMsg('File Path', '/apis')
+			),
+		})) as string;
+
+		paths.push(path);
+
+		askPaths = await askList({
+			msg: gitLabPrompts.ENTER_MORE_PATHS,
+			default: YesNo.No,
+			choices: YesNoChoices,
+		}) === YesNo.Yes;
+	}
+	return paths;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const askForGitLabFilters = async (): Promise<string[]> => {
+	let askFilters = true;
+	const filters = [];
+	console.log(chalk.gray('An array of regular expressions that a file name must match to be discovered'));
+	while (askFilters) {
+		const filter = (await askInput({
+			msg: gitLabPrompts.FILTERS,
+			allowEmptyInput: true,
+		})) as string;
+
+		if (filter.trim() !== '') {
+			filters.push(filter);
+			askFilters = await askList({
+				msg: gitLabPrompts.ENTER_MORE_FILTERS,
+				default: YesNo.No,
+				choices: YesNoChoices,
+			}) === YesNo.Yes;
+		} else {
+			askFilters = false;
+		}
+	}
+
+	return filters;
+};
+
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<GitLabAgentValues> => {
+	const gitLabAgentValues: GitLabAgentValues = new GitLabAgentValues();
+	if (installConfig.switches.isDockerInstall) {
+		console.log('\nCONNECTION TO GitHub API GATEWAY:');
+		console.log(
+			chalk.gray('The Discovery Agent needs to connect to the GitHub API Gateway to discover API\'s for publishing to Amplify Engage.')
+		);
+
+		gitLabAgentValues.token = await askForGitLabToken();
+		gitLabAgentValues.baseURL = await askForGitLabBaseURL();
+		gitLabAgentValues.repositoryID = await askForGitLabRepositoryID();
+		gitLabAgentValues.repositoryBranch = await askForGitLabRepositoryBranch();
+		gitLabAgentValues.paths = await askForGitLabPaths();
+		gitLabAgentValues.filters = await askForGitLabFilters();
+	}
+	return gitLabAgentValues;
+};
+
+const dockerSuccessMsg = (installConfig: AgentInstallConfig) => {
+	let dockerInfo;
+	const runDaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runDaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startDaLinuxMsg = '\nStart the Discovery Agent on a Linux based machine';
+	const startDaWinMsg = '\nStart the Discovery Agent on a Windows machine';
+
+	if (installConfig.switches.isDaEnabled) {
+		dockerInfo = `To utilize the discovery agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.DA_ENV_VARS}):`;
+	}
+	console.log(chalk.whiteBright(dockerInfo), '\n');
+
+	if (installConfig.switches.isDaEnabled) {
+		const daImageVersion = `${daImage}:${installConfig.daVersion}`;
+		console.log(chalk.white('Pull the latest image of the Discovery Agent:'));
+		console.log(chalk.cyan(`docker pull ${daImageVersion}`));
+		console.log(chalk.white(isWindows ? startDaWinMsg : startDaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runDaWinMsg : runDaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${daImageVersion}`));
+	}
+};
+
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	const configType = installConfig.deploymentType;
+
+	if (configType === AgentConfigTypes.DOCKERIZED) {
+		dockerSuccessMsg(installConfig);
+	}
+};
+
+export const installPreprocess = async (installConfig: AgentInstallConfig): Promise<AgentInstallConfig> => {
+
+	return installConfig;
+};
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	/**
+	 * Create agent resources
+	 */
+	const gitLabAgentValues = installConfig.gatewayConfig as GitLabAgentValues;
+
+	// Add final settings to gitLabAgentValues
+	gitLabAgentValues.centralConfig = installConfig.centralConfig;
+	gitLabAgentValues.daVersion = installConfig.daVersion;
+
+	if (installConfig.switches.isDockerInstall) {
+		if (installConfig.switches.isDaEnabled) {
+			writeTemplates(ConfigFiles.DAEnvVars, gitLabAgentValues, helpers.gitLabDAEnvVarTemplate);
+		}
+	}
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	generateSuccessHelpMsg(installConfig);
 };
 
 export const GitLabInstallMethods: InstallationFlowMethods = {
 	GetBundleType: askBundleType,
 	GetDeploymentType: askConfigType,
 	AskGatewayQuestions: gatewayConnectivity,
+	InstallPreprocess: installPreprocess,
 	FinalizeGatewayInstall: completeInstall,
 	ConfigFiles: Object.values(ConfigFiles),
-	AgentNameMap: {
-		[AgentTypes.da]: AgentNames.GITLAB_DA,
-	},
 	GatewayDisplay: GatewayTypes.GITLAB,
 };

--- a/src/lib/engage/utils/agents/flows/graylogAgents.ts
+++ b/src/lib/engage/utils/agents/flows/graylogAgents.ts
@@ -1,35 +1,173 @@
+import chalk from 'chalk';
 import { InstallationFlowMethods } from '../../../services/install-service.js';
 import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import { askInput, validateRegex } from '../../basic-prompts.js';
+import { AgentHelmInfo, helmImageSecretInfo, helmInstallInfo, writeTemplates } from '../../utils.js';
 import { GraylogAgentValues } from '../index.js';
 import * as helpers from '../index.js';
+import { kubectl } from '../kubectl.js';
 
-export const askBundleType = async (): Promise<BundleType> => {
-	return BundleType.TRACEABILITY as BundleType;
-};
+export const amplifyAgentsNs = 'amplify-agents';
 
+// ConfigFiles - all the config file that are used in the setup
 export const ConfigFiles = {
 	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
 };
 
+// GraylogPrompts - prompts for user inputs
 const prompts = {
-	configTypeMsg: 'Select the mode of installation',
+	agentNamespace: 'Enter the namespace to use for the Amplify Graylog Agents',
+	enterUrl: 'Enter the Graylog base URL that the agent will use',
+	enterUsername: 'Enter the Graylog user name',
+	enterPassword: 'Enter the password for Graylog user',
+	enterBasePathSegmentLen: 'Enter the base path segment length that agent will use for lookup',
+};
+
+export const askBundleType = async (): Promise<BundleType> => {
+	return  BundleType.TRACEABILITY as BundleType;
 };
 
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
-	})) as AgentConfigTypes;
+	return AgentConfigTypes.HELM;
 };
+
+//
+// Questions for the configuration of Graylog agent
+//
+const askURL = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterUrl,
+		allowEmptyInput: false,
+		validate: validateRegex(
+			helpers.GitLabRegexPatterns.gitLabBaseURLRegex,
+			helpers.invalidValueExampleErrMsg('BaseURL', 'https://www.testdomain.com')
+		)
+	})) as string;
+
+const askUsername = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterUsername,
+		allowEmptyInput: false,
+	})) as string;
+
+const askPassword = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterPassword,
+	})) as string;
+
+const askBasePathSegmentLen = async (): Promise<number> =>
+	(await askInput({
+		msg: prompts.enterBasePathSegmentLen,
+		type: 'number',
+		defaultValue: 2
+	})) as number;
 
 export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<GraylogAgentValues> => {
-	const values: GraylogAgentValues = new GraylogAgentValues();
-	return values;
+	console.log(
+		chalk.gray('The Amplify Graylog Agent needs to be deployed to your Kubernetes cluster to discover APIs for publishing to Amplify Engage.')
+	);
+
+	const { error } = await kubectl.isInstalled();
+	if (error) {
+		throw new Error(
+			`Kubectl is required to fill out the following prompts. It appears to be missing or misconfigured.\n${error}`
+		);
+	}
+
+	const graylogAgentValues: GraylogAgentValues = new GraylogAgentValues();
+	graylogAgentValues.namespace = await helpers.askNamespace(prompts.agentNamespace, amplifyAgentsNs);
+	graylogAgentValues.url = await askURL();
+	graylogAgentValues.userName = await askUsername();
+	graylogAgentValues.password = await askPassword();
+	graylogAgentValues.basePathSegmentLen = await askBasePathSegmentLen();
+
+	return graylogAgentValues;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const generateSuccessHelpMsg = (namespace: string) => {
+	console.log(`Graylog Agent override file has been placed at ${process.cwd()}/${ConfigFiles.helmOverride}`);
+	helmImageSecretInfo(namespace);
+
+	const agentHelmInfo = new Set<AgentHelmInfo>();
+	agentHelmInfo.add({
+		helmReleaseName: 'graylog-agent',
+		helmChartName: 'axway/graylog-agent',
+		overrideFileName: ConfigFiles.helmOverride,
+		imageSecretOverrides: '--set image.pullSecret=<image-pull-secret-name>' });
+
+	helmInstallInfo(
+		'Graylog',
+		namespace,
+		agentHelmInfo
+	);
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.GRAYLOG}`)
+	);
+};
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	// Add final settings to graylogAgentValues
+	const graylogAgentValues = installConfig.gatewayConfig as GraylogAgentValues;
+	if (graylogAgentValues.namespace.isNew) {
+		await helpers.createNamespace(graylogAgentValues.namespace.name);
+	}
+	graylogAgentValues.centralConfig = installConfig.centralConfig;
+	graylogAgentValues.graylogSecret = helpers.amplifyAgentsCredsSecret;
+	graylogAgentValues.agentKeysSecret = helpers.amplifyAgentsKeysSecret;
+	// read file content
+	await helpers.createSecret(graylogAgentValues.namespace.name, helpers.amplifyAgentsKeysSecret, async () => {
+		if (installConfig.centralConfig.ampcDosaInfo.isNew) {
+			console.log(
+				chalk.yellow(
+					`The secret '${helpers.amplifyAgentsKeysSecret}' will be created with the same "private_key.pem" and "public_key.pem" that was auto generated to create the Service Account.`
+				)
+			);
+		}
+
+		await helpers.createAmplifyAgentKeysSecret(
+			graylogAgentValues.namespace.name,
+			helpers.amplifyAgentsKeysSecret,
+			'publicKey',
+			graylogAgentValues.centralConfig.dosaAccount.publicKey,
+			'privateKey',
+			graylogAgentValues.centralConfig.dosaAccount.privateKey
+		);
+	});
+	await helpers.createSecret(graylogAgentValues.namespace.name, helpers.amplifyAgentsCredsSecret, async () => {
+		await createGraylogCredsSecret(
+			graylogAgentValues.namespace.name,
+			helpers.amplifyAgentsCredsSecret,
+			graylogAgentValues.userName,
+			graylogAgentValues.password,
+		);
+	});
+	graylogAgentValues.traceabilityConfig = installConfig.traceabilityConfig;
+
+	console.log('Generating the configuration file(s)...');
+	writeTemplates(ConfigFiles.helmOverride, graylogAgentValues, helpers.graylogHelmOverrideTemplate);
+
+	generateSuccessHelpMsg(graylogAgentValues.namespace.name);
+};
+
+const createGraylogCredsSecret = async (
+	namespace: string,
+	secretName: string,
+	user: string,
+	password: string
+): Promise<void> => {
+	const { error } = await kubectl.create(
+		'secret',
+		`-n ${namespace} generic ${secretName} \
+		--from-literal=username=${user} \
+		--from-literal=password=${password}`
+	);
+	if (error) {
+		throw Error(error);
+	}
+	console.log(`Created ${secretName} in the ${namespace} namespace.`);
 };
 
 export const GraylogInstallMethods: InstallationFlowMethods = {
@@ -43,3 +181,4 @@ export const GraylogInstallMethods: InstallationFlowMethods = {
 	},
 	GatewayDisplay: GatewayTypes.GRAYLOG,
 };
+

--- a/src/lib/engage/utils/agents/flows/ibmAPIConnetAgents.ts
+++ b/src/lib/engage/utils/agents/flows/ibmAPIConnetAgents.ts
@@ -1,38 +1,230 @@
-import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import chalk from 'chalk';
+import { InstallationFlowMethods, svcAccMsg } from '../../../services/install-service.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, PublicDockerRepoBaseUrl } from '../../../types.js';
+import { askInput, askList } from '../../basic-prompts.js';
+import { isWindows, writeTemplates } from '../../utils.js';
 import { IBMAPIConnectAgentValues } from '../index.js';
 import * as helpers from '../index.js';
 
+const daImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.IBMAPICONNECT_DA}`;
+const taImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.IBMAPICONNECT_TA}`;
+
+export const defaultLogFiles = '/group-*_instance-*.log';
+
+// ConfigFiles - all the config file that are used in the setup
+export const ConfigFiles = {
+	DAEnvVars: `${helpers.configFiles.DA_ENV_VARS}`,
+	TAEnvVars: `${helpers.configFiles.TA_ENV_VARS}`,
+	IBMAPIConnectDABinaryFile: 'discovery_agent',
+	IBMAPIConnectDAYaml: 'discovery_agent.yml',
+	IBMAPIConnectTABinaryFile: 'traceability_agent',
+	IBMAPIConnectTAYaml: 'traceability_agent.yml',
+};
+
+// IBMAPIConnectPrompts - prompts for user inputs
+const IBMAPIConnectPrompts = {
+	configTypeMsg: 'Select the mode of installation',
+	enterApiConnectURL: 'Enter the IBM API Connect URL',
+	enterApiConnectOrgName: 'Enter the IBM API Connect Organization Name',
+	enterApiConnectCatalogName: 'Enter the IBM API Connect Catalog Name',
+	enterApiConnectAuthAPIKey: 'Enter the IBM API Connect Auth API Key',
+	enterApiConnectAuthClientID: 'Enter the IBM API Connect Client ID',
+	enterApiConnectAuthClientSecret: 'Enter the IBM API Connect Client Secret',
+	enterApiConnectConsumerOrgOwnerUser: 'Enter the IBM API Connect Consumer Organization Owner User',
+	enterApiConnectConsumerOrgOwnerRegistry: 'Enter the IBM API Connect Consumer Organization Owner User Registry',
+	enterApiConnectAnalyticsServerName: 'Enter the IBM API Connect Analytics Server Name',
+};
+
 export const askBundleType = async (): Promise<BundleType> => {
 	return (await askList({
-		msg: 'Select the type of agent(s) you want to install',
+		msg: helpers.agentMessages.selectAgentType,
 		choices: [ BundleType.ALL_AGENTS, BundleType.DISCOVERY, BundleType.TRACEABILITY ],
 	})) as BundleType;
 };
 
-export const ConfigFiles = {
-	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
-};
-
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
-};
-
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
-	})) as AgentConfigTypes;
+	return AgentConfigTypes.DOCKERIZED;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<IBMAPIConnectAgentValues> => {
-	const values: IBMAPIConnectAgentValues = new IBMAPIConnectAgentValues();
-	return values;
+//
+// Questions for the configuration of IBM API Connect agents
+//
+const askIBMAPIConnectURL = async (): Promise<string> =>
+	(await askInput({
+		msg: IBMAPIConnectPrompts.enterApiConnectURL,
+	})) as string;
+
+const askIBMAPIConnectOrgName = async (): Promise<string> =>
+	(await askInput({
+		msg: IBMAPIConnectPrompts.enterApiConnectOrgName,
+	})) as string;
+
+const askIBMAPIConnectCatalogName = async (): Promise<string> =>
+	(await askInput({
+		msg: IBMAPIConnectPrompts.enterApiConnectCatalogName,
+	})) as string;
+
+const askIBMAPIConnectAuthAPIKey = async (): Promise<string> =>
+	(await askInput({
+		msg: IBMAPIConnectPrompts.enterApiConnectAuthAPIKey,
+	})) as string;
+
+const askIBMAPIConnectClientID = async (): Promise<string> =>
+	(await askInput({
+		msg: IBMAPIConnectPrompts.enterApiConnectAuthClientID,
+	})) as string;
+
+const askIBMAPIConnectClientSecret = async (): Promise<string> =>
+	(await askInput({
+		msg: IBMAPIConnectPrompts.enterApiConnectAuthClientSecret,
+	})) as string;
+
+const askIBMAPIConnectOrgOwnerUser = async (): Promise<string> =>
+	(await askInput({
+		msg: IBMAPIConnectPrompts.enterApiConnectConsumerOrgOwnerUser,
+	})) as string;
+
+const askIBMAPIConnectOrgOwnerRegistry = async (): Promise<string> =>
+	(await askInput({
+		msg: IBMAPIConnectPrompts.enterApiConnectConsumerOrgOwnerRegistry,
+	})) as string;
+
+const askIBMAPIConnectAnalyticsServerName = async (): Promise<string> =>
+	(await askInput({
+		msg: IBMAPIConnectPrompts.enterApiConnectAnalyticsServerName,
+	})) as string;
+
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<IBMAPIConnectAgentValues> => {
+	const ibmAPIConnectAgentValues: IBMAPIConnectAgentValues = new IBMAPIConnectAgentValues();
+	console.log('\nCONNECTION TO IBM API Connect:');
+	console.log(
+		chalk.gray(
+			'The discovery agent needs to connect to the IBM API Connect Gateway to discover API\'s for publishing to Amplify.\nThe traceability agent needs to connect to IBM API Connect for collecting APIs transactions. These will be forwarded to the Business Insights.\n'
+		)
+	);
+
+	await askCommonPrompts(ibmAPIConnectAgentValues);
+
+	// IBM API Connect Discovery Agent Prompts
+	if (installConfig.switches.isDaEnabled) {
+		console.log(chalk.gray('\nDiscovery Agent Configuration\n'));
+
+		await askDiscoveryPrompts(ibmAPIConnectAgentValues);
+	}
+
+	// IBM API Connect Traceability Agent Prompts
+	if (installConfig.switches.isTaEnabled) {
+		console.log(chalk.gray('\nTraceability Agent Configuration\n'));
+
+		await askTraceabilityPrompts(ibmAPIConnectAgentValues);
+	}
+
+	return ibmAPIConnectAgentValues;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	if (installConfig.centralConfig.ampcDosaInfo.isNew && !installConfig.switches.isHelmInstall) {
+		console.log(chalk.yellow(svcAccMsg));
+	}
+
+	dockerSuccessMsg(installConfig);
+
+	console.log(
+		chalk.gray(
+			`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.IBMAPICONNECT}`
+		)
+	);
+};
+
+const dockerSuccessMsg = (installConfig: AgentInstallConfig) => {
+	let dockerInfo;
+	const runDaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runDaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const runTaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runTaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startDaLinuxMsg = '\nStart the Discovery Agent on a Linux based machine';
+	const startDaWinMsg = '\nStart the Discovery Agent on a Windows machine';
+	const startTaLinuxMsg = '\nStart the Traceability Agent on a Linux based machine';
+	const startTaWinMsg = '\nStart the Traceability Agent on a Windows machine';
+
+	if (installConfig.switches.isDaEnabled && installConfig.switches.isTaEnabled) {
+		dockerInfo = `To utilize the agents, pull the latest Docker images and run them using the appropriate supplied environment files, (${helpers.configFiles.DA_ENV_VARS} & ${helpers.configFiles.TA_ENV_VARS}):`;
+	} else if (installConfig.switches.isDaEnabled) {
+		dockerInfo = `To utilize the discovery agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.DA_ENV_VARS}):`;
+	} else {
+		dockerInfo = `To utilize the traceability agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.TA_ENV_VARS}):`;
+	}
+	console.log(chalk.whiteBright(dockerInfo), '\n');
+
+	if (installConfig.switches.isDaEnabled) {
+		const daImageVersion = `${daImage}:${installConfig.daVersion}`;
+		console.log(chalk.white('Pull the latest image of the Discovery Agent:'));
+		console.log(chalk.cyan(`docker pull ${daImageVersion}`));
+		console.log(chalk.white(isWindows ? startDaWinMsg : startDaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runDaWinMsg : runDaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${daImageVersion}`), '\n');
+	}
+	if (installConfig.switches.isTaEnabled) {
+		const taImageVersion = `${taImage}:${installConfig.taVersion}`;
+		console.log(chalk.white('Pull the latest image of the Traceability Agent:'));
+		console.log(chalk.cyan(`docker pull ${taImageVersion}`));
+		console.log(chalk.white(isWindows ? startTaWinMsg : startTaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runTaWinMsg : runTaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${taImageVersion}`), '\n');
+	}
+};
+
+async function askCommonPrompts(ibmAPIConnectAgentValues: IBMAPIConnectAgentValues) {
+	// IBM API Connect URL
+	ibmAPIConnectAgentValues.apiConnectURL = await askIBMAPIConnectURL();
+	// IBM API Connect Org Name
+	ibmAPIConnectAgentValues.apiConnectOrgName = await askIBMAPIConnectOrgName();
+	// IBM API Connect Catalog Name
+	ibmAPIConnectAgentValues.apiConnectCatalogName = await askIBMAPIConnectCatalogName();
+	// IBM API Connect Auth API Key
+	ibmAPIConnectAgentValues.apiConnectAuthAPIKey = await askIBMAPIConnectAuthAPIKey();
+	// IBM API Connect Auth Client ID
+	ibmAPIConnectAgentValues.apiConnectAuthClientID = await askIBMAPIConnectClientID();
+	// IBM API Connect Auth Client Secret
+	ibmAPIConnectAgentValues.apiConnectAuthClientSecret = await askIBMAPIConnectClientSecret();
+}
+
+// IBM API Connect DA prompts
+async function askDiscoveryPrompts(ibmAPIConnectAgentValues: IBMAPIConnectAgentValues) {
+	// IBM API Connect Consumer Org Owner User
+	ibmAPIConnectAgentValues.apiConnectConsumerOrgOwnerUser = await askIBMAPIConnectOrgOwnerUser();
+	// IBM API Connect Consumer Org Owner Registry
+	ibmAPIConnectAgentValues.apiConnectConsumerOrgOwnerRegistry = await askIBMAPIConnectOrgOwnerRegistry();
+}
+
+async function askTraceabilityPrompts(ibmAPIConnectAgentValues: IBMAPIConnectAgentValues) {
+	// IBM API Connect Analytics Server Name
+	ibmAPIConnectAgentValues.apiConnectAnalyticsServerName = await askIBMAPIConnectAnalyticsServerName();
+}
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	/**
+	 * Create agent resources
+	 */
+	const ibmAPIConnectAgentValues = installConfig.gatewayConfig as IBMAPIConnectAgentValues;
+
+	// Add final settings to ibmAPIConnectAgentValues
+	ibmAPIConnectAgentValues.centralConfig = installConfig.centralConfig;
+	ibmAPIConnectAgentValues.traceabilityConfig = installConfig.traceabilityConfig;
+
+	console.log('Generating the configuration file(s)...');
+
+	if (installConfig.switches.isDaEnabled) {
+		writeTemplates(ConfigFiles.DAEnvVars, ibmAPIConnectAgentValues, helpers.ibmAPIConnectDAEnvVarTemplate);
+	}
+
+	if (installConfig.switches.isTaEnabled) {
+		writeTemplates(ConfigFiles.TAEnvVars, ibmAPIConnectAgentValues, helpers.ibmAPIConnectTAEnvVarTemplate);
+	}
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	generateSuccessHelpMsg(installConfig);
 };
 
 export const IBMAPIConnectInstallMethods: InstallationFlowMethods = {

--- a/src/lib/engage/utils/agents/flows/istioAgents.ts
+++ b/src/lib/engage/utils/agents/flows/istioAgents.ts
@@ -1,44 +1,449 @@
+import chalk from 'chalk';
 import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import { AgentConfigTypes, AgentInstallConfig, BundleType, Certificate, GatewayTypes, IstioAgentValues, IstioInstallValues, IstioProfileChoices, Protocol, YesNo, YesNoChoices } from '../../../types.js';
+import { createTlsCert } from '../../bash-commands.js';
+import { askInput, askList, validateRegex } from '../../basic-prompts.js';
+import { AgentHelmInfo, helmImageSecretInfo, helmInstallInfo, writeTemplates } from '../../utils.js';
 import * as helpers from '../index.js';
 import { IstioValues } from '../index.js';
+import { kubectl, KubectlResponse } from '../kubectl.js';
+
+export const amplifyAgentsNs = 'amplify-agents';
+export const gatewayCertSecret = 'gateway-cert';
+export const istioSystemNs = 'istio-system';
+export const ampcDemoNs = 'ampc-demo';
+
+export const defaultLogFiles = '/group-*_instance-*.log';
+export const amplifyAgentsCredsSecret = 'amplify-agents-credentials';
+
+export enum AlsMode {
+	Verbose = 'verbose',
+	Default = 'default',
+	Ambient = 'ambient',
+}
+
+// ConfigFiles - all the config file that are used in the setup
+export const ConfigFiles = {
+	IstioOverrideFile: 'istio-override.yaml',
+	HybridOverrideFile: 'hybrid-override.yaml',
+};
+
+export const istioPrompts = {
+	// istio
+	enterProtocol: 'Enter the protocol to use for the ingress gateway',
+	enterPort: 'Enter the Kubernetes cluster port',
+	enterIstioSecret: 'Enter the name of the secret to store the Istio gateway certificate',
+	generateCertPrompt: 'Would you like to generate a self signed certificate, or provide your own?',
+	enterDomainName: 'Enter the public domain name for your cluster (FQDN), if available. (leave blank to skip)',
+	enterCertPath: 'Enter the file path to the certificate',
+	existingIstio: 'Use existing Istio installation?',
+	askEnvoyFilterNamespace: 'Select the namespace where you would like the ALS Envoy Filters to be applied',
+	istioProfile: 'Select the Istio profile to use',
+
+	// agents
+	meshAgentNamespace: 'Enter the namespace to use for the Amplify Istio Agents',
+	vsNamespaces: 'Select the namespace where the agent should discover Virtual Service resources',
+	alsMode: 'Select Traceability Agent HTTP header publishing mode',
+	demoService: 'Do you want to deploy the optional demo application?',
+};
 
 export const askBundleType = async (): Promise<BundleType> => {
 	return (await askList({
-		msg: 'Select the type of agent(s) you want to install',
+		msg: helpers.agentMessages.selectAgentType,
 		choices: [ BundleType.ALL_AGENTS, BundleType.DISCOVERY, BundleType.TRACEABILITY ],
 	})) as BundleType;
 };
 
-export const ConfigFiles = {
-	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
-};
-
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
-};
-
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.HELM ],
-	})) as AgentConfigTypes;
+	return AgentConfigTypes.DOCKERIZED;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<IstioValues> => {
-	const values: IstioValues = new IstioValues();
-	return values;
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<IstioValues> => {
+	const istioValues: IstioValues = new IstioValues();
+
+	console.log('\nCONNECTING A KUBERNETES CLUSTER TO AMPLIFY CENTRAL\n');
+	console.log(
+		chalk.gray(`The Amplify Istio Discovery Agent needs to be deployed to your Kubernetes cluster to discover APIs for publishing to Amplify Central and/or the Amplify Marketplace.
+The Amplify Istio Traceability Agent needs to be deployed to your Kubernetes cluster to collect transaction telemetry to send to the Amplify Central Observer and Visibility Dashboard.`)
+	);
+	console.log(`
+For more details on client prerequesites or Kubernetes preparation refer to the documentation here:
+https://docs.axway.com/bundle/amplify-central/page/docs/connect_manage_environ/mesh_management/build_hybrid_env/index.html
+`);
+
+	const { error } = await kubectl.isInstalled();
+	if (error) {
+		throw new Error(
+			`Kubectl is required to fill out the following prompts. It appears to be missing or misconfigured.\n${error}`
+		);
+	}
+
+	const istioOverrides = await setupIstio(istioValues);
+
+	installConfig.gatewayConfig = istioValues;
+
+	// Set up the following values from installConfig to be used in setupKubernetes
+	istioValues.istioAgentValues.alsEnabled = installConfig.switches.isTaEnabled;
+	istioValues.istioAgentValues.discoveryEnabled = installConfig.switches.isDaEnabled;
+
+	const hybridOverrides = await setupKubernetes(istioValues);
+	hybridOverrides.envoyFilterNamespace = istioOverrides.envoyFilterNamespace;
+
+	istioOverrides.alsNamespace = hybridOverrides.namespace.name;
+	istioOverrides.enableAls = hybridOverrides.alsMode === AlsMode.Verbose;
+	istioOverrides.enableTracing = hybridOverrides.alsEnabled;
+
+	return istioValues;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+// Questions for the istio configuration
+const askUseExistingIstio = async (): Promise<string> =>
+	askList({
+		msg: istioPrompts.existingIstio,
+		choices: YesNoChoices,
+	});
+
+const askEnvoyFilterNamespace = async (namespaces: KubectlResponse): Promise<string> =>
+	askList({
+		msg: istioPrompts.askEnvoyFilterNamespace,
+		choices: namespaces.data,
+	});
+
+const askHost = async (): Promise<string> =>
+	(await askInput({
+		msg: istioPrompts.enterDomainName,
+		validate: validateRegex(helpers.domainNameRegex, helpers.invalidDomainName),
+		allowEmptyInput: true,
+	})) as string;
+
+const askProtocol = async (): Promise<string> =>
+	askList({
+		msg: istioPrompts.enterProtocol,
+		choices: [
+			{
+				name: Protocol.HTTP.toUpperCase(),
+				value: Protocol.HTTP,
+			},
+			{
+				name: Protocol.HTTPS.toUpperCase(),
+				value: Protocol.HTTPS,
+			},
+		],
+	});
+
+const askPort = async (protocol: string): Promise<number> =>
+	(await askInput({
+		msg: istioPrompts.enterPort,
+		type: 'number',
+		defaultValue: protocol === Protocol.HTTP ? 8080 : 443,
+	})) as number;
+
+const askCertificateOption = async (): Promise<string> =>
+	askList({
+		msg: istioPrompts.generateCertPrompt,
+		choices: [
+			{ name: 'Generate self signed certificate', value: Certificate.GENERATE },
+			{ name: 'Provide certificate', value: Certificate.PROVIDE },
+		],
+	});
+
+const askIstioProfile = async (): Promise<string> =>
+	askList({
+		msg: istioPrompts.istioProfile,
+		choices: IstioProfileChoices,
+	});
+
+export const setupIstio = async (istioValues: IstioValues): Promise<IstioInstallValues> => {
+	const istioInstallValues = istioValues.istioInstallValues;
+	console.log(chalk.gray('If Istio is not yet installed, select No. If Istio is already running select Yes.\n'));
+
+	const useExistingIstio = await askUseExistingIstio();
+
+	if (useExistingIstio === YesNo.Yes) {
+		const namespaces = await kubectl.get('namespaces');
+		if (namespaces.error) {
+			throw new Error(namespaces.error);
+		}
+
+		const filterNamespace = await askEnvoyFilterNamespace(namespaces);
+
+		istioInstallValues.envoyFilterNamespace = filterNamespace;
+		istioInstallValues.isNewInstall = false;
+		return istioInstallValues;
+	}
+
+	istioInstallValues.profile = await askIstioProfile();
+
+	console.log(
+		chalk.gray(
+			'\nFor a Kubernetes cluster exposing HTTPS endpoints, you must own or be able to configure a certificate for the correspoinding fully qualified domain name\n'
+		)
+	);
+
+	istioInstallValues.host = (await askHost()).toLowerCase();
+
+	if (istioInstallValues.host) {
+		istioInstallValues.protocol = await askProtocol();
+		istioInstallValues.port = await askPort(istioInstallValues.protocol);
+
+		if (istioInstallValues.protocol === Protocol.HTTPS) {
+			istioInstallValues.certSecretName = await askIstioSecret(
+				istioPrompts.enterIstioSecret,
+				istioSystemNs,
+				gatewayCertSecret
+			);
+			istioInstallValues.certificateOption = await askCertificateOption();
+		}
+	}
+
+	istioInstallValues.targetPort = istioInstallValues.protocol === Protocol.HTTP ? 8080 : 8443;
+	return istioValues.istioInstallValues;
+};
+
+export const askIstioSecret = async (msg: string, namespace: string, defaultSecretName: string) => {
+	const allSecrets = await kubectl.get('secrets', `-n ${namespace}`);
+	// No resources errors are ok. Throw an error for anything else.
+	if (allSecrets.error && !allSecrets.error.includes('K8S secrets: No resources found')) {
+		throw Error(allSecrets.error);
+	}
+	return helpers.askForSecretName(msg, defaultSecretName, allSecrets.data);
+};
+
+const completeIstio = async (istioOverrides: IstioInstallValues) => {
+	if (istioOverrides.protocol === Protocol.HTTPS) {
+		if (istioOverrides.isNewInstall) {
+			await kubectl.create('ns', istioSystemNs);
+		}
+		await createIstioGatewayCert(istioOverrides.envoyFilterNamespace, istioOverrides);
+	}
+};
+
+// Above this line is Istio.  Below is Kubernetes
+
+// Questions for the kubernetes configuration
+const askALSMode = async (): Promise<string> => {
+	return askList({
+		msg: istioPrompts.alsMode,
+		choices: [
+			{
+				name: AlsMode.Ambient.charAt(0).toUpperCase() + AlsMode.Ambient.slice(1),
+				value: AlsMode.Ambient,
+			},
+			{
+				name: AlsMode.Default.charAt(0).toUpperCase() + AlsMode.Default.slice(1),
+				value: AlsMode.Default,
+			},
+			{
+				name: AlsMode.Verbose.charAt(0).toUpperCase() + AlsMode.Verbose.slice(1),
+				value: AlsMode.Verbose,
+			},
+		],
+		default: AlsMode.Ambient,
+	});
+};
+
+const askVsNamespacePrompt = async (): Promise<string> => {
+	const namespaces = await kubectl.get('ns');
+	if (namespaces.error) {
+		throw Error(namespaces.error);
+	}
+
+	return await askList({
+		msg: istioPrompts.vsNamespaces,
+		choices: namespaces.data,
+	});
+};
+
+const askEnableDemoSvc = async (): Promise<boolean> => {
+	const res = askList({
+		msg: istioPrompts.demoService,
+		choices: YesNoChoices,
+	});
+
+	return (await res) === YesNo.Yes;
+};
+
+// Setup Overrides
+export const setupKubernetes = async (
+	istioValues: IstioValues,
+): Promise<IstioAgentValues> => {
+	const istioAgentValues = istioValues.istioAgentValues;
+
+	console.log(
+		chalk.gray(
+			'\nThere are several steps to prepare a Kubernetes cluster for the Amplify Istio Agents.\nThe following questions collect the namespace and secret to use for the Istio gateway.\n'
+		)
+	);
+
+	if (istioAgentValues.alsEnabled) {
+		console.log(
+			chalk.gray(
+				'\nThe Istio Traceability Agent supports three modes: default (minimal required header subset), ambient (baseline headers with optional Telemetry CR emission), and verbose (capture all request/response headers).\n'
+			)
+		);
+
+		istioAgentValues.alsMode = await askALSMode();
+	}
+
+	if (istioAgentValues.discoveryEnabled) {
+		const ns = await askVsNamespacePrompt();
+		istioAgentValues.discoveryNamespaces = [ ns ];
+	}
+
+	istioAgentValues.namespace = await helpers.askNamespace(istioPrompts.meshAgentNamespace, amplifyAgentsNs);
+	istioAgentValues.demoSvcEnabled = await askEnableDemoSvc();
+
+	if (
+		istioAgentValues.discoveryEnabled
+		&& istioAgentValues.demoSvcEnabled
+		&& !istioAgentValues.discoveryNamespaces.includes(ampcDemoNs)
+	) {
+		istioAgentValues.discoveryNamespaces.push(ampcDemoNs);
+	}
+
+	// set keySecretName
+	istioAgentValues.keysSecretName = helpers.amplifyAgentsKeysSecret;
+
+	istioAgentValues.clusterName = await helpers.askClusterName();
+
+	return istioAgentValues;
+};
+
+export const createIstioGatewayCert = async (namespace: string, istioOverrides: IstioInstallValues) => {
+	let privateKey = '';
+	let cert = '';
+	if (istioOverrides.certificateOption === Certificate.GENERATE) {
+		({ cert, privateKey } = await createTlsCert(
+			istioOverrides.certSecretName as string,
+			istioOverrides.host as string
+		));
+		console.log(
+			`Created ${istioOverrides.certSecretName}.crt and ${istioOverrides.certSecretName}.key in ${process.cwd()}`
+		);
+	} else {
+		privateKey = (await askInput({ msg: helpers.enterPublicKeyPath })) as string;
+		cert = (await askInput({ msg: istioPrompts.enterCertPath })) as string;
+	}
+	const { data, error } = await kubectl.create(
+		'secret',
+		`-n ${namespace} tls ${istioOverrides.certSecretName} --cert=${cert} --key=${privateKey}`
+	);
+	if (error) {
+		throw new Error(error);
+	}
+	console.log(`Created ${data[0]} in the ${namespace} namespace.`);
+};
+
+export const createIstioOverride = (overrides: IstioValues): void => {
+	const overrideFileName = ConfigFiles.IstioOverrideFile;
+
+	writeTemplates(overrideFileName, overrides, helpers.istioInstallTemplate);
+
+	console.log(`\nIstio override file has been placed at ${process.cwd()}/${overrideFileName}`);
+	if (overrides.istioInstallValues.isNewInstall) {
+		console.log(
+			'To complete the istio installation run the following command:',
+			chalk.cyan(`\n  istioctl install --set profile=${overrides.istioInstallValues.profile} -f ${overrideFileName}\n`)
+		);
+	} else {
+		console.log(
+			chalk.cyan(
+				`  Please merge the generated ${overrideFileName} file with your Istio configuration to allow the Traceability Agent to function.\n`
+			)
+		);
+	}
+};
+
+export const createHybridOverride = (overrides: IstioValues) => {
+	const overrideFileName = ConfigFiles.HybridOverrideFile;
+
+	writeTemplates(overrideFileName, overrides, helpers.istioAgentsTemplate);
+
+	console.log(`Istio agent override file has been placed at ${process.cwd()}/${overrideFileName}`);
+	helmImageSecretInfo(overrides.istioAgentValues.namespace.name);
+
+	const agentHelmInfo = new Set<AgentHelmInfo>();
+	agentHelmInfo.add({
+		helmReleaseName: 'ampc-hybrid',
+		helmChartName: 'axway/ampc-hybrid',
+		overrideFileName: overrideFileName,
+		imageSecretOverrides: '--set da.image.pullSecret=<image-pull-secret-name> --set als.image.pullSecret=<image-pull-secret-name>' });
+
+	helmInstallInfo(
+		'Istio',
+		overrides.istioAgentValues.namespace.name,
+		agentHelmInfo
+	);
+};
+
+export const installPreprocess = async (installConfig: AgentInstallConfig): Promise<AgentInstallConfig> => {
+	// name of the service account, and if it is new or not
+
+	if (!installConfig.centralConfig.ampcDosaInfo.isNew) {
+		[ installConfig.centralConfig.dosaAccount.publicKey, installConfig.centralConfig.dosaAccount.privateKey ]
+			= await helpers.askPublicAndPrivateKeysPath();
+	} else {
+		console.log(
+			chalk.yellow(
+				'The secret will be created with the same "private_key.pem" and "public_key.pem" that will be auto generated to create the Service Account, following the completion of these prompts.'
+			)
+		);
+	}
+
+	return installConfig;
+};
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	// Contents of completeKubernetes moved here.
+
+	const istioValues = installConfig.gatewayConfig as IstioValues;
+
+	// Add final settings to IstioAgentsValues
+	istioValues.centralConfig = installConfig.centralConfig;
+	istioValues.traceabilityConfig = installConfig.traceabilityConfig;
+
+	await completeIstio(istioValues.istioInstallValues);
+
+	if (istioValues.istioAgentValues.namespace.isNew) {
+		await helpers.createNamespace(istioValues.istioAgentValues.namespace.name);
+	}
+
+	await helpers.createSecret(istioValues.istioAgentValues.namespace.name, helpers.amplifyAgentsKeysSecret, async () => {
+		if (installConfig.centralConfig.ampcDosaInfo.isNew) {
+			console.log(
+				chalk.yellow(
+					`The secret '${helpers.amplifyAgentsKeysSecret}' will be created with the same "private_key.pem" and "public_key.pem" that was auto generated to create the Service Account.`
+				)
+			);
+		}
+
+		await helpers.createAmplifyAgentKeysSecret(
+			istioValues.istioAgentValues.namespace.name,
+			helpers.amplifyAgentsKeysSecret,
+			'publicKey',
+			istioValues.centralConfig.dosaAccount.publicKey,
+			'privateKey',
+			istioValues.centralConfig.dosaAccount.privateKey
+		);
+	});
+
+	console.log('Generating the configuration file(s)...');
+
+	createIstioOverride(istioValues);
+	createHybridOverride(istioValues);
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.ISTIO}`)
+	);
 };
 
 export const IstioInstallMethods: InstallationFlowMethods = {
 	GetBundleType: askBundleType,
 	GetDeploymentType: askConfigType,
 	AskGatewayQuestions: gatewayConnectivity,
+	InstallPreprocess: installPreprocess,
 	FinalizeGatewayInstall: completeInstall,
 	ConfigFiles: Object.values(ConfigFiles),
 	GatewayDisplay: GatewayTypes.ISTIO,

--- a/src/lib/engage/utils/agents/flows/kafkaAgents.ts
+++ b/src/lib/engage/utils/agents/flows/kafkaAgents.ts
@@ -1,38 +1,326 @@
-import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import chalk from 'chalk';
+import { InstallationFlowMethods, svcAccMsg } from '../../../services/install-service.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, PublicDockerRepoBaseUrl, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList, validateRegex } from '../../basic-prompts.js';
+import { isWindows, writeTemplates } from '../../utils.js';
 import { KafkaAgentValues } from '../index.js';
 import * as helpers from '../index.js';
 
+const daImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.KAFKA_DA}`;
+const taImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.KAFKA_TA}`;
+
+// ConfigFiles - all the config file that are used in the setup
+export const ConfigFiles = {
+	DAEnvVars: `${helpers.configFiles.DA_ENV_VARS}`,
+	TAEnvVars: `${helpers.configFiles.TA_ENV_VARS}`,
+};
+
+// DeploymentTypes - types of Kafka cluster deployments
+export enum DeploymentTypes {
+	CONFLUENT_CLOUD = 'Confluent Cloud',
+	CONFLUENT_PLATFORM = 'Confluent Platform',
+}
+
+// SaslMechanismTypes - SASL authentication mechanism types
+export enum SaslMechanismTypes {
+	SCRAM_SHA_256 = 'SCRAM-SHA-256',
+	SCRAM_SHA_512 = 'SCRAM-SHA-512',
+	PLAIN = 'PLAIN',
+	OAUTHBEARER = 'OAUTHBEARER',
+	NONE = 'NONE',
+}
+
+// KafkaPrompts - prompts for user inputs
+const prompts = {
+	deploymentTypeMsg: 'Select the type of deployment you wish to configure',
+	enterEnvironmentId: 'Enter the Environment Id',
+	enterClusterId: 'Enter the Cluster Id',
+	enterCloudAPIKey: 'Enter the Cloud API Key Id',
+	enterCloudAPISecret: 'Enter the Cloud API Key Secret',
+
+	enterClusterServer: 'Enter the Bootstrap Server Name',
+	enterClusterAPIKey: 'Enter the Cluster API Key Id',
+	enterClusterAPISecret: 'Enter the Cluster API Key Secret',
+	saslMechanismMsg: 'Select the SASL Mechanism you wish to use for authentication',
+	enterSaslUsername: 'Enter the SASL Username',
+	enterSaslPassword: 'Enter the SASL Password',
+	enterSaslOAuthTokenUrl: 'Enter the SASL/OAUTHBEARER Token Url',
+	enterSaslOAuthClientId: 'Enter the SASL/OAUTHBEARER Client Id',
+	enterSaslOAuthClientSecret: 'Enter the SASL/OAUTHBEARER Client Secret',
+	enterSaslOAuthClientScopes: 'Enter the SASL/OAUTHBEARER Client Scopes(comma separated list)',
+
+	schemaRegistryEnabledMsg: 'Do you want to use Schema Registry with Kafka cluster?',
+	enterSchemaRegistryUrl: 'Enter the Schema Registry Url',
+	schemaRegistryAuthEnabled: 'Do you want to authenticate Schema Registry with SASL mechanism?',
+	enterSchemaRegistryAPIKey: 'Enter the Schema Registry API Key Id',
+	enterSchemaRegistryAPISecret: 'Enter the Schema Registry API Key Secret',
+};
+
 export const askBundleType = async (): Promise<BundleType> => {
 	return (await askList({
-		msg: 'Select the type of agent(s) you want to install',
+		msg: helpers.agentMessages.selectAgentType,
 		choices: [ BundleType.ALL_AGENTS, BundleType.DISCOVERY, BundleType.TRACEABILITY ],
 	})) as BundleType;
 };
 
-export const ConfigFiles = {
-	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
-};
-
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
-};
-
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
-	})) as AgentConfigTypes;
+	return AgentConfigTypes.DOCKERIZED;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<KafkaAgentValues> => {
-	const values: KafkaAgentValues = new KafkaAgentValues();
-	return values;
+//
+// Questions for the configuration of Kafka agents
+//
+export const askIsCloudEnabled = async (): Promise<boolean> => {
+	const deploymentType = await askList({
+		msg: prompts.deploymentTypeMsg,
+		default: DeploymentTypes.CONFLUENT_CLOUD,
+		choices: [
+			{ name: DeploymentTypes.CONFLUENT_CLOUD, value: DeploymentTypes.CONFLUENT_CLOUD },
+			{ name: DeploymentTypes.CONFLUENT_PLATFORM, value: DeploymentTypes.CONFLUENT_PLATFORM },
+		],
+	});
+	return deploymentType === DeploymentTypes.CONFLUENT_CLOUD;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const askEnvironmentId = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterEnvironmentId,
+	})) as string;
+
+const askClusterId = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterClusterId,
+	})) as string;
+
+const askCloudAPIKey = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterCloudAPIKey,
+	})) as string;
+
+const askCloudAPISecret = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterCloudAPISecret,
+	})) as string;
+
+const askClusterServer = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterClusterServer,
+		validate: validateRegex(
+			helpers.KafkaRegexPatterns.bootstrapServerRegex,
+			helpers.invalidValueExampleErrMsg('Bootstrap Server Name', 'SASL_SSL://somehost.testdomain.com:9092')
+		),
+	})) as string;
+
+const askClusterAPIKey = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterClusterAPIKey,
+	})) as string;
+
+const askClusterAPISecret = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterClusterAPISecret,
+	})) as string;
+
+export const askSaslMechanism = async (): Promise<string> => {
+	return await askList({
+		msg: prompts.saslMechanismMsg,
+		default: SaslMechanismTypes.PLAIN,
+		choices: [
+			{ name: SaslMechanismTypes.NONE, value: SaslMechanismTypes.NONE },
+			{ name: SaslMechanismTypes.PLAIN, value: SaslMechanismTypes.PLAIN },
+			{ name: SaslMechanismTypes.SCRAM_SHA_256, value: SaslMechanismTypes.SCRAM_SHA_256 },
+			{ name: SaslMechanismTypes.SCRAM_SHA_512, value: SaslMechanismTypes.SCRAM_SHA_512 },
+			{ name: SaslMechanismTypes.OAUTHBEARER, value: SaslMechanismTypes.OAUTHBEARER },
+		],
+	});
+};
+
+const askSaslOAuthBearerTokenUrl = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterSaslOAuthTokenUrl,
+		allowEmptyInput: false,
+		validate: validateRegex(
+			helpers.KafkaRegexPatterns.urlRegex,
+			helpers.invalidValueExampleErrMsg('Token URL', 'https://www.testdomain.com/oauth/token')
+		),
+	})) as string;
+
+const askSaslOAuthBearerClientId = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterSaslOAuthClientId,
+		allowEmptyInput: false,
+	})) as string;
+
+const askSaslOAuthBearerClientSecret = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterSaslOAuthClientSecret,
+		allowEmptyInput: false,
+	})) as string;
+
+const askSaslOAuthBearerScopes = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterSaslOAuthClientScopes,
+		allowEmptyInput: true,
+	})) as string;
+
+const askSaslUsername = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterSaslUsername,
+	})) as string;
+
+const askSaslPassword = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterSaslPassword,
+	})) as string;
+
+const askIsSchemaRegistryEnabled = async (): Promise<boolean> => {
+	const enabled = await askList({
+		msg: prompts.schemaRegistryEnabledMsg,
+		default: YesNo.Yes,
+		choices: YesNoChoices,
+	});
+	return enabled === YesNo.Yes;
+};
+
+export const askIsSchemaRegistryAuthEnabled = async (): Promise<boolean> => {
+	const enabled = await askList({
+		msg: prompts.schemaRegistryAuthEnabled,
+		default: YesNo.Yes,
+		choices: YesNoChoices
+	});
+	return enabled === YesNo.Yes;
+};
+
+const askSchemaRegistryUrl = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterSchemaRegistryUrl,
+		validate: validateRegex(
+			helpers.KafkaRegexPatterns.urlRegex,
+			helpers.invalidValueExampleErrMsg('Schema Registry Url', 'https://www.testdomain.com')
+		),
+	})) as string;
+
+const askSchemaRegistryAPIKey = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterSchemaRegistryAPIKey,
+	})) as string;
+
+const askSchemaRegistryAPISecret = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterSchemaRegistryAPISecret,
+	})) as string;
+
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<KafkaAgentValues> => {
+	const kafkaAgentValues: KafkaAgentValues = new KafkaAgentValues();
+	kafkaAgentValues.cloudEnabled = await askIsCloudEnabled();
+
+	if (kafkaAgentValues.cloudEnabled) {
+		kafkaAgentValues.cloudEnvironmentId = await askEnvironmentId();
+		kafkaAgentValues.cloudClusterId = await askClusterId();
+		kafkaAgentValues.cloudAPIKey = await askCloudAPIKey();
+		kafkaAgentValues.cloudAPISecret = await askCloudAPISecret();
+		kafkaAgentValues.clusterAPIKey = await askClusterAPIKey();
+		kafkaAgentValues.clusterAPISecret = await askClusterAPISecret();
+	} else {
+		kafkaAgentValues.clusterServer = await askClusterServer();
+		kafkaAgentValues.clusterSaslMechanism = await askSaslMechanism();
+		if (kafkaAgentValues.clusterSaslMechanism !== SaslMechanismTypes.NONE) {
+			if (kafkaAgentValues.clusterSaslMechanism === SaslMechanismTypes.OAUTHBEARER) {
+				kafkaAgentValues.saslOauthTokenUrl = await askSaslOAuthBearerTokenUrl();
+				kafkaAgentValues.saslOauthClientId = await askSaslOAuthBearerClientId();
+				kafkaAgentValues.saslOauthClientSecret = await askSaslOAuthBearerClientSecret();
+				kafkaAgentValues.saslOauthClientScopes = await askSaslOAuthBearerScopes();
+			} else {
+				kafkaAgentValues.clusterSaslUser = await askSaslUsername();
+				kafkaAgentValues.clusterSaslPassword = await askSaslPassword();
+			}
+		}
+	}
+
+	if (installConfig.switches.isDaEnabled) {
+		if (kafkaAgentValues.cloudEnabled) {
+			kafkaAgentValues.schemaRegistryAPIKey = await askSchemaRegistryAPIKey();
+			kafkaAgentValues.schemaRegistryAPISecret = await askSchemaRegistryAPISecret();
+		} else {
+			kafkaAgentValues.schemaRegistryEnabled = await askIsSchemaRegistryEnabled();
+			if (kafkaAgentValues.schemaRegistryEnabled) {
+				kafkaAgentValues.schemaRegistryUrl = await askSchemaRegistryUrl();
+				kafkaAgentValues.schemaRegistryAuthEnabled = await askIsSchemaRegistryAuthEnabled();
+			}
+		}
+	}
+	return kafkaAgentValues;
+};
+
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	if (installConfig.centralConfig.ampcDosaInfo.isNew && !installConfig.switches.isHelmInstall) {
+		console.log(chalk.yellow(svcAccMsg));
+	}
+
+	dockerSuccessMsg(installConfig);
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.AZURE}`)
+	);
+};
+
+const dockerSuccessMsg = (installConfig: AgentInstallConfig) => {
+	let dockerInfo;
+	const runDaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runDaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const runTaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runTaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startDaLinuxMsg = '\nStart the Discovery Agent on a Linux based machine';
+	const startDaWinMsg = '\nStart the Discovery Agent on a Windows machine';
+	const startTaLinuxMsg = '\nStart the Traceability Agent on a Linux based machine';
+	const startTaWinMsg = '\nStart the Traceability Agent on a Windows machine';
+
+	if (installConfig.switches.isDaEnabled && installConfig.switches.isTaEnabled) {
+		dockerInfo = `To utilize the agents, pull the latest Docker images and run them using the appropriate supplied environment files, (${helpers.configFiles.DA_ENV_VARS} & ${helpers.configFiles.TA_ENV_VARS}):`;
+	} else if (installConfig.switches.isDaEnabled) {
+		dockerInfo = `To utilize the discovery agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.DA_ENV_VARS}):`;
+	} else {
+		dockerInfo = `To utilize the traceability agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.TA_ENV_VARS}):`;
+	}
+	console.log(chalk.whiteBright(dockerInfo), '\n');
+
+	if (installConfig.switches.isDaEnabled) {
+		const daImageVersion = `${daImage}:${installConfig.daVersion}`;
+		console.log(chalk.white('Pull the latest image of the Discovery Agent:'));
+		console.log(chalk.cyan(`docker pull ${daImageVersion}`));
+		console.log(chalk.white(isWindows ? startDaWinMsg : startDaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runDaWinMsg : runDaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${daImageVersion}`), '\n');
+	}
+	if (installConfig.switches.isTaEnabled) {
+		const taImageVersion = `${taImage}:${installConfig.taVersion}`;
+		console.log(chalk.white('Pull the latest image of the Traceability Agent:'));
+		console.log(chalk.cyan(`docker pull ${taImageVersion}`));
+		console.log(chalk.white(isWindows ? startTaWinMsg : startTaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runTaWinMsg : runTaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${taImageVersion}`), '\n');
+	}
+};
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	// Add final settings to kafkaAgentsValues
+	const kafkaAgentValues = installConfig.gatewayConfig as KafkaAgentValues;
+	kafkaAgentValues.centralConfig = installConfig.centralConfig;
+	kafkaAgentValues.traceabilityConfig = installConfig.traceabilityConfig;
+
+	console.log('Generating the configuration file(s)...');
+
+	if (installConfig.switches.isDaEnabled) {
+		writeTemplates(ConfigFiles.DAEnvVars, kafkaAgentValues, helpers.kafkaDAEnvVarTemplate);
+	}
+
+	if (installConfig.switches.isTaEnabled) {
+		writeTemplates(ConfigFiles.TAEnvVars, kafkaAgentValues, helpers.kafkaTAEnvVarTemplate);
+	}
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	generateSuccessHelpMsg(installConfig);
 };
 
 export const KafkaInstallMethods: InstallationFlowMethods = {

--- a/src/lib/engage/utils/agents/flows/sapApiPortalAgents.ts
+++ b/src/lib/engage/utils/agents/flows/sapApiPortalAgents.ts
@@ -1,38 +1,217 @@
-import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
-import { SAPApiPortalAgentValues } from '../templates/sapApiPortalTemplates.js';
+import { InstallationFlowMethods, svcAccMsg } from '../../../services/install-service.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, PublicDockerRepoBaseUrl, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList } from '../../basic-prompts.js';
+import { SAPApiPortalAgentValues, sapAPIPortalDAEnvVarTemplate, sapAPIPortalTAEnvVarTemplate } from '../templates/sapApiPortalTemplates.js';
 import * as helpers from '../index.js';
+import chalk from 'chalk';
+import { isWindows, writeTemplates } from '../../utils.js';
+
+const daImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.SAPAPIPORTAL_DA}`;
+const taImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.SAPAPIPORTAL_TA}`;
+
+export const defaultLogFiles = '/group-*_instance-*.log';
+
+// ConfigFiles - all the config file that are used in the setup
+export const ConfigFiles = {
+	DAEnvVars: `${helpers.configFiles.DA_ENV_VARS}`,
+	TAEnvVars: `${helpers.configFiles.TA_ENV_VARS}`,
+	SAPAPIPortalDABinaryFile: 'discovery_agent',
+	SAPAPIPortalDAYaml: 'discovery_agent.yml',
+	SAPAPIPortalTABinaryFile: 'traceability_agent',
+	SAPAPIPortalTAYaml: 'traceability_agent.yml',
+};
+
+// SAPAPIPortalPrompts - prompts for user inputs
+const SAPAPIPortalPrompts = {
+	configTypeMsg: 'Select the mode of installation',
+	enterAuthTokenURL: 'Enter the token URL used for agent authentication to SAP',
+	enterAuthAPIPortalBaseURL: 'Enter the SAP API Portal baseURL',
+	enterAuthAPIPortalClientID: 'Enter the SAP API Portal ClientID',
+	enterAuthAPIPortalClientSecret: 'Enter the SAP API Portal ClientSecret',
+	enterAuthDevPortalBaseURL: 'Enter the SAP Dev Portal baseURL',
+	enterAuthDevPortalClientID: 'Enter the SAP Dev Portal ClientID',
+	enterAuthDevPortalClientSecret: 'Enter the SAP Dev Portal ClientSecret',
+	enterDeveloperEmail: 'Enter the SAP developer email',
+	selectSpecCreateUnstructuredAPI: 'Select whether to create unstructured APIs for invalid/unknown API specs',
+};
 
 export const askBundleType = async (): Promise<BundleType> => {
 	return (await askList({
-		msg: 'Select the type of agent(s) you want to install',
+		msg: helpers.agentMessages.selectAgentType,
 		choices: [ BundleType.ALL_AGENTS, BundleType.DISCOVERY, BundleType.TRACEABILITY ],
 	})) as BundleType;
 };
 
-export const ConfigFiles = {
-	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
-};
-
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
-};
-
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
-	})) as AgentConfigTypes;
+	return AgentConfigTypes.DOCKERIZED;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<SAPApiPortalAgentValues> => {
-	const values: SAPApiPortalAgentValues = new SAPApiPortalAgentValues();
-	return values;
+//
+// Questions for the configuration of SAP API Portal agents
+//
+const askAuthTokenURL = async (): Promise<string> =>
+	(await askInput({
+		msg: SAPAPIPortalPrompts.enterAuthTokenURL,
+	})) as string;
+
+const askAuthAPIPortalBaseURL = async (): Promise<string> =>
+	(await askInput({
+		msg: SAPAPIPortalPrompts.enterAuthAPIPortalBaseURL,
+	})) as string;
+
+const askAuthAPIPortalClientID = async (): Promise<string> =>
+	(await askInput({
+		msg: SAPAPIPortalPrompts.enterAuthAPIPortalClientID,
+	})) as string;
+
+const askAuthAPIPortalClientSecret = async (): Promise<string> =>
+	(await askInput({
+		msg: SAPAPIPortalPrompts.enterAuthAPIPortalClientSecret,
+	})) as string;
+
+const askAuthDevPortalBaseURL = async (): Promise<string> =>
+	(await askInput({
+		msg: SAPAPIPortalPrompts.enterAuthDevPortalBaseURL,
+	})) as string;
+
+const askAuthDevPortalClientID = async (): Promise<string> =>
+	(await askInput({
+		msg: SAPAPIPortalPrompts.enterAuthDevPortalClientID,
+	})) as string;
+
+const askAuthDevPortalClientSecret = async (): Promise<string> =>
+	(await askInput({
+		msg: SAPAPIPortalPrompts.enterAuthDevPortalClientSecret,
+	})) as string;
+
+const askDeveloperEmail = async (): Promise<string> =>
+	(await askInput({
+		msg: SAPAPIPortalPrompts.enterDeveloperEmail,
+	})) as string;
+
+const askSpecCreateUnstructuredAPI = async (): Promise<boolean> =>
+	(await askList({
+		msg: SAPAPIPortalPrompts.selectSpecCreateUnstructuredAPI,
+		default: YesNo.No,
+		choices: YesNoChoices,
+	})) as YesNo === YesNo.Yes;
+
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<SAPApiPortalAgentValues> => {
+	const agentValues: SAPApiPortalAgentValues = new SAPApiPortalAgentValues();
+	console.log('\nCONNECTION TO SAP API Portal:');
+	console.log(
+		chalk.gray(
+			'The discovery agent needs to connect to the SAP API Portal Gateway to discover API\'s for publishing to Amplify.\nThe traceability agent needs to connect to SAP API Portal for collecting APIs transactions. These will be forwarded to the Business Insights.\n'
+		)
+	);
+
+	await askCommonPrompts(agentValues);
+
+	// SAP API Portal Discovery Agent Prompts
+	if (installConfig.switches.isDaEnabled) {
+		console.log(
+			chalk.gray(
+				'\nDiscovery Agent Configuration\n'
+			)
+		);
+
+		await askDiscoveryPrompts(agentValues);
+	}
+
+	return agentValues;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	if (installConfig.centralConfig.ampcDosaInfo.isNew && !installConfig.switches.isHelmInstall) {
+		console.log(chalk.yellow(svcAccMsg));
+	}
+
+	dockerSuccessMsg(installConfig);
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.SAPAPIPORTAL}`)
+	);
+};
+
+const dockerSuccessMsg = (installConfig: AgentInstallConfig) => {
+	let dockerInfo;
+	const runDaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runDaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const runTaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runTaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startDaLinuxMsg = '\nStart the Discovery Agent on a Linux based machine';
+	const startDaWinMsg = '\nStart the Discovery Agent on a Windows machine';
+	const startTaLinuxMsg = '\nStart the Traceability Agent on a Linux based machine';
+	const startTaWinMsg = '\nStart the Traceability Agent on a Windows machine';
+
+	if (installConfig.switches.isDaEnabled && installConfig.switches.isTaEnabled) {
+		dockerInfo = `To utilize the agents, pull the latest Docker images and run them using the appropriate supplied environment files, (${helpers.configFiles.DA_ENV_VARS} & ${helpers.configFiles.TA_ENV_VARS}):`;
+	} else if (installConfig.switches.isDaEnabled) {
+		dockerInfo = `To utilize the discovery agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.DA_ENV_VARS}):`;
+	} else {
+		dockerInfo = `To utilize the traceability agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.TA_ENV_VARS}):`;
+	}
+	console.log(chalk.whiteBright(dockerInfo), '\n');
+
+	if (installConfig.switches.isDaEnabled) {
+		const daImageVersion = `${daImage}:${installConfig.daVersion}`;
+		console.log(chalk.white('Pull the latest image of the Discovery Agent:'));
+		console.log(chalk.cyan(`docker pull ${daImageVersion}`));
+		console.log(chalk.white(isWindows ? startDaWinMsg : startDaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runDaWinMsg : runDaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${daImageVersion}`), '\n');
+	}
+	if (installConfig.switches.isTaEnabled) {
+		const taImageVersion = `${taImage}:${installConfig.taVersion}`;
+		console.log(chalk.white('Pull the latest image of the Traceability Agent:'));
+		console.log(chalk.cyan(`docker pull ${taImageVersion}`));
+		console.log(chalk.white(isWindows ? startTaWinMsg : startTaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runTaWinMsg : runTaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${taImageVersion}`), '\n');
+	}
+};
+
+async function askCommonPrompts(agentValues: SAPApiPortalAgentValues) {
+	agentValues.authTokenURL = await askAuthTokenURL();
+
+	agentValues.authAPIPortalBaseURL = await askAuthAPIPortalBaseURL();
+	agentValues.authAPIPortalClientID = await askAuthAPIPortalClientID();
+	agentValues.authAPIPortalClientSecret = await askAuthAPIPortalClientSecret();
+}
+
+// SAP API Portal DA prompts
+async function askDiscoveryPrompts(agentValues: SAPApiPortalAgentValues) {
+	agentValues.authDevPortalBaseURL = await askAuthDevPortalBaseURL();
+	agentValues.authDevPortalClientID = await askAuthDevPortalClientID();
+	agentValues.authDevPortalClientSecret = await askAuthDevPortalClientSecret();
+
+	agentValues.developerEmail = await askDeveloperEmail();
+	agentValues.specCreateUnstructuredAPI = await askSpecCreateUnstructuredAPI();
+}
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	/**
+	 * Create agent resources
+	 */
+	const agentValues = installConfig.gatewayConfig as SAPApiPortalAgentValues;
+
+	// Add final settings to SAP API Portal agentValues
+	agentValues.centralConfig = installConfig.centralConfig;
+	agentValues.traceabilityConfig = installConfig.traceabilityConfig;
+
+	console.log('Generating the configuration file(s)...');
+
+	if (installConfig.switches.isDaEnabled) {
+		writeTemplates(ConfigFiles.DAEnvVars, agentValues, sapAPIPortalDAEnvVarTemplate);
+	}
+
+	if (installConfig.switches.isTaEnabled) {
+		writeTemplates(ConfigFiles.TAEnvVars, agentValues, sapAPIPortalTAEnvVarTemplate);
+	}
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	generateSuccessHelpMsg(installConfig);
 };
 
 export const SAPAPIPortalInstallMethods: InstallationFlowMethods = {

--- a/src/lib/engage/utils/agents/flows/sensediaAgents.ts
+++ b/src/lib/engage/utils/agents/flows/sensediaAgents.ts
@@ -1,38 +1,241 @@
-import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import chalk from 'chalk';
+import { InstallationFlowMethods, svcAccMsg } from '../../../services/install-service.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, PublicDockerRepoBaseUrl, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList, validateRegex } from '../../basic-prompts.js';
+import { isWindows, writeTemplates } from '../../utils.js';
 import { SensediaAgentValues } from '../index.js';
 import * as helpers from '../index.js';
 
-export const askBundleType = async (): Promise<BundleType> => {
-	return (await askList({
-		msg: 'Select the type of agent(s) you want to install',
-		choices: [ BundleType.ALL_AGENTS, BundleType.DISCOVERY, BundleType.TRACEABILITY ],
-	})) as BundleType;
-};
+const daImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.SENSEDIA_DA}`;
+const taImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.SENSEDIA_TA}`;
 
+// ConfigFiles - all the config file that are used in the setup
 export const ConfigFiles = {
-	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
+	DAEnvVars: `${helpers.configFiles.DA_ENV_VARS}`,
+	TAEnvVars: `${helpers.configFiles.TA_ENV_VARS}`,
+	SensediaDABinaryFile: 'discovery_agent',
+	SensediaDAYaml: 'discovery_agent.yml',
+	SensediaTABinaryFile: 'traceability_agent',
+	SensediaTAYaml: 'traceability_agent.yml',
 };
 
-const prompts = {
+// SensediaPrompts - prompts for user inputs
+const SensediaPrompts = {
 	configTypeMsg: 'Select the mode of installation',
+	enterBaseUrl: 'Enter the Sensedia Base URL',
+	selectAuthMethod: 'Select the authentication method',
+	enterClientId: 'Enter the Sensedia Client ID',
+	enterClientSecret: 'Enter the Sensedia Client Secret',
+	enterAuthToken: 'Enter the Sensedia Authentication Token',
+	enterDeveloperEmail: 'Enter the Developer Email',
+	enterEnvironments: 'Do you want to configure specific environments for discovery and reporting? If no value is provided, discovery occurs on all the environments',
+	enterMoreEnvironments: 'Enter an environment name (or press Enter to finish)',
+	invalidEnvironmentMessage: 'Commas are not allowed in the name due to the way the agent parses the environments list. Make sure you input one environment name at a time'
+};
+
+export const askBundleType = async (gateway?: GatewayTypes): Promise<BundleType> => {
+	console.log(gateway);
+	if (gateway === GatewayTypes.SENSEDIA) {
+		return (await askList({
+			msg: helpers.agentMessages.selectAgentType,
+			choices: [ BundleType.ALL_AGENTS, BundleType.DISCOVERY ],
+		})) as BundleType;
+	} else {
+		return BundleType.DISCOVERY;
+	}
 };
 
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
-	})) as AgentConfigTypes;
+	return AgentConfigTypes.DOCKERIZED;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<SensediaAgentValues> => {
-	const values: SensediaAgentValues = new SensediaAgentValues();
-	return values;
+//
+// Questions for the configuration of Sensedia agents
+//
+const askSensediaBaseUrl = async (): Promise<string> =>
+	(await askInput({
+		msg: SensediaPrompts.enterBaseUrl,
+		validate: validateRegex(
+			helpers.SensediaRegexPatterns.urlRegex,
+			helpers.invalidValueExampleErrMsg('baseURL', 'https://sensedia.com'),
+		),
+	})) as string;
+
+const askSensediaAuthMethod = async (): Promise<string> =>
+	(await askList({
+		msg: SensediaPrompts.selectAuthMethod,
+		choices: [
+			{ name: helpers.SensediaAuthType.OAuth, value: helpers.SensediaAuthType.OAuth },
+			{ name: helpers.SensediaAuthType.StaticToken, value: helpers.SensediaAuthType.StaticToken },
+		],
+	})) as string;
+
+const askSensediaClientId = async (): Promise<string> =>
+	(await askInput({
+		msg: SensediaPrompts.enterClientId,
+	})) as string;
+
+const askSensediaClientSecret = async (): Promise<string> =>
+	(await askInput({
+		msg: SensediaPrompts.enterClientSecret,
+	})) as string;
+
+const askSensediaAuthToken = async (): Promise<string> =>
+	(await askInput({
+		msg: SensediaPrompts.enterAuthToken,
+	})) as string;
+
+const askSensediaDeveloperEmail = async (): Promise<string> =>
+	(await askInput({
+		msg: SensediaPrompts.enterDeveloperEmail,
+		validate: validateRegex(
+			helpers.SensediaRegexPatterns.emailRegex,
+			helpers.invalidValueExampleErrMsg('DeveloperEmail', 'dev@gmail.com'),
+		),
+	})) as string;
+
+const askSensediaEnvironments = async (): Promise<string[]> => {
+	const environments: string[] = [];
+	const addEnvironments: boolean = (await askList({
+		msg: SensediaPrompts.enterEnvironments,
+		default: YesNo.No,
+		choices: YesNoChoices,
+	})) === YesNo.Yes;
+	// eslint-disable-next-line no-unmodified-loop-condition
+	while (addEnvironments) {
+		const env = (await askInput({
+			msg: SensediaPrompts.enterMoreEnvironments,
+			validate: validateRegex(
+				helpers.SensediaRegexPatterns.noCommaRegex,
+				SensediaPrompts.invalidEnvironmentMessage,
+			),
+			allowEmptyInput: true,
+		})) as string;
+		if (env && env.trim() !== '') {
+			environments.push(env);
+		} else {
+			return environments;
+		}
+	}
+	return environments;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<SensediaAgentValues> => {
+	const SensediaAgentValues: SensediaAgentValues = new helpers.SensediaAgentValues();
+
+	console.log('\nCONNECTION TO Sensedia:');
+	console.log(
+		chalk.gray(
+			'The discovery agent needs to connect to the Sensedia to discover API\'s for publishing to Amplify.\nThe traceability agent needs to connect to an Sensedia for collecting APIs transactions. These will be forwarded to the Business Insights.\n'
+		)
+	);
+
+	// Sensedia Discovery Agent Prompts
+	if (installConfig.switches.isDaEnabled) {
+		console.log(chalk.gray('\nDiscovery Agent Configuration\nThe discovery agent needs to connect to Sensedia.'));
+		await askDiscoveryPrompts(SensediaAgentValues);
+	}
+
+	return SensediaAgentValues;
+};
+
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	if (installConfig.centralConfig.ampcDosaInfo.isNew && !installConfig.switches.isHelmInstall) {
+		console.log(chalk.yellow(svcAccMsg));
+	}
+
+	dockerSuccessMsg(installConfig);
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.SENSEDIA}`)
+	);
+};
+
+const dockerSuccessMsg = (installConfig: AgentInstallConfig) => {
+	let dockerInfo;
+	const runDaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runDaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const runTaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runTaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startDaLinuxMsg = '\nStart the Discovery Agent on a Linux based machine';
+	const startDaWinMsg = '\nStart the Discovery Agent on a Windows machine';
+	const startTaLinuxMsg = '\nStart the Traceability Agent on a Linux based machine';
+	const startTaWinMsg = '\nStart the Traceability Agent on a Windows machine';
+
+	if (installConfig.switches.isDaEnabled && installConfig.switches.isTaEnabled) {
+		dockerInfo = `To utilize the agents, pull the latest Docker images and run them using the appropriate supplied environment files, (${helpers.configFiles.DA_ENV_VARS} & ${helpers.configFiles.TA_ENV_VARS}):`;
+	} else if (installConfig.switches.isDaEnabled) {
+		dockerInfo = `To utilize the discovery agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.DA_ENV_VARS}):`;
+	} else {
+		dockerInfo = `To utilize the traceability agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.TA_ENV_VARS}):`;
+	}
+	console.log(chalk.whiteBright(dockerInfo), '\n');
+
+	if (installConfig.switches.isDaEnabled) {
+		const daImageVersion = `${daImage}:${installConfig.daVersion}`;
+		console.log(chalk.white('Pull the latest image of the Discovery Agent:'));
+		console.log(chalk.cyan(`docker pull ${daImageVersion}`));
+		console.log(chalk.white(isWindows ? startDaWinMsg : startDaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runDaWinMsg : runDaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${daImageVersion}`), '\n');
+	}
+	if (installConfig.switches.isTaEnabled) {
+		const taImageVersion = `${taImage}:${installConfig.taVersion}`;
+		console.log(chalk.white('Pull the latest image of the Traceability Agent:'));
+		console.log(chalk.cyan(`docker pull ${taImageVersion}`));
+		console.log(chalk.white(isWindows ? startTaWinMsg : startTaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runTaWinMsg : runTaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${taImageVersion}`), '\n');
+	}
+};
+
+// Sensedia DA prompts
+async function askDiscoveryPrompts(sensediaAgentValues: SensediaAgentValues) {
+	// Sensedia Base URL
+	sensediaAgentValues.baseUrl = await askSensediaBaseUrl();
+
+	// Sensedia Authentication Method
+	sensediaAgentValues.authType = await askSensediaAuthMethod();
+
+	if (sensediaAgentValues.authType === helpers.SensediaAuthType.OAuth) {
+		// OAuth authentication
+		sensediaAgentValues.clientId = await askSensediaClientId();
+		sensediaAgentValues.clientSecret = await askSensediaClientSecret();
+	} else {
+		// Static token authentication
+		sensediaAgentValues.authToken = await askSensediaAuthToken();
+	}
+
+	// Sensedia Developer Email
+	sensediaAgentValues.developerEmail = await askSensediaDeveloperEmail();
+
+	// Sensedia Environments
+	sensediaAgentValues.environments = [ ...new Set(await askSensediaEnvironments()) ];
+}
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	/**
+	 * Create agent resources
+	 */
+	const sensediaAgentValues = installConfig.gatewayConfig as SensediaAgentValues;
+
+	// Add final settings to SensediaAgentsValues
+	sensediaAgentValues.centralConfig = installConfig.centralConfig;
+	sensediaAgentValues.traceabilityConfig = installConfig.traceabilityConfig;
+
+	console.log('Generating the configuration file(s)...');
+
+	if (installConfig.switches.isDaEnabled) {
+		writeTemplates(ConfigFiles.DAEnvVars, sensediaAgentValues, helpers.sensediaDAEnvVarTemplate);
+	}
+
+	if (installConfig.switches.isTaEnabled) {
+		writeTemplates(ConfigFiles.TAEnvVars, sensediaAgentValues, helpers.sensediaTAEnvVarTemplate);
+	}
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	generateSuccessHelpMsg(installConfig);
 };
 
 export const SensediaInstallMethods: InstallationFlowMethods = {

--- a/src/lib/engage/utils/agents/flows/softwareAGWebMethodAgents.ts
+++ b/src/lib/engage/utils/agents/flows/softwareAGWebMethodAgents.ts
@@ -1,38 +1,161 @@
-import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import chalk from 'chalk';
+import { InstallationFlowMethods, svcAccMsg } from '../../../services/install-service.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, PublicDockerRepoBaseUrl } from '../../../types.js';
+import { askInput, askList } from '../../basic-prompts.js';
+import { isWindows, writeTemplates } from '../../utils.js';
 import { SoftwareAGWebMethodsAgentValues } from '../index.js';
 import * as helpers from '../index.js';
 
+const daImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.SOFTWAREAGWEBMETHODS_DA}`;
+const taImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.SOFTWAREAGWEBMETHODS_TA}`;
+
+// ConfigFiles - all the config file that are used in the setup
+export const ConfigFiles = {
+	DAEnvVars: `${helpers.configFiles.DA_ENV_VARS}`,
+	TAEnvVars: `${helpers.configFiles.TA_ENV_VARS}`,
+};
+
+// WebMethods - prompts for user inputs
+const prompts = {
+	pathURL: 'Enter the base URL to connect to your Software AG WebMethods API service',
+	pathUsername: 'Enter the username to authenticate to Software AG WebMethods',
+	pathPassword: 'Enter the password to authenticate to Software AG WebMethods',
+	pathOauth2Server: 'Enter the OAuth2 server to authenticate. Defaults to local gateway auth',
+};
+
 export const askBundleType = async (): Promise<BundleType> => {
 	return (await askList({
-		msg: 'Select the type of agent(s) you want to install',
+		msg: helpers.agentMessages.selectAgentType,
 		choices: [ BundleType.ALL_AGENTS, BundleType.DISCOVERY, BundleType.TRACEABILITY ],
 	})) as BundleType;
 };
 
-export const ConfigFiles = {
-	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
-};
-
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
-};
-
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
-	})) as AgentConfigTypes;
+	return AgentConfigTypes.DOCKERIZED;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<SoftwareAGWebMethodsAgentValues> => {
-	const values: SoftwareAGWebMethodsAgentValues = new SoftwareAGWebMethodsAgentValues();
-	return values;
+//
+// Questions for the configuration of Software AG WebMethods agents
+//
+async function askCommonPrompts(webMethodsAgentValues: SoftwareAGWebMethodsAgentValues) {
+	// Software AG WebMethods Path URL
+	webMethodsAgentValues.pathURL = await askPathURL();
+	// Software AG WebMethods Path Username
+	webMethodsAgentValues.pathUsername = await askPathUsername();
+	// Software AG WebMethods Path Password
+	webMethodsAgentValues.pathPassword = await askPathPassword();
+	// Software AG WebMethods Path Oauth2Server
+	webMethodsAgentValues.pathOauth2Server = await askPathOauth2Server();
+	if (webMethodsAgentValues.pathOauth2Server.trim() === '') {
+		webMethodsAgentValues.pathOauth2Server = 'local';
+	}
+}
+const askPathURL = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.pathURL,
+	})) as string;
+
+const askPathUsername = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.pathUsername,
+	})) as string;
+
+const askPathPassword = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.pathPassword,
+	})) as string;
+
+const askPathOauth2Server = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.pathOauth2Server,
+		allowEmptyInput: true,
+		defaultValue: 'local'
+	})) as string;
+
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<SoftwareAGWebMethodsAgentValues> => {
+	const webMethodsAgentValues: SoftwareAGWebMethodsAgentValues = new SoftwareAGWebMethodsAgentValues();
+	console.log('\nCONNECTION TO Software AG WebMethods:');
+	console.log(
+		chalk.gray(
+			'The discovery agent needs to connect to the Software AG WebMethods Gateway to discover API\'s for publishing to Amplify.\nThe traceability agent needs to connect to Software AG WebMethods for collecting APIs transactions. These will be forwarded to the Business Insights.\n'
+		)
+	);
+	if (installConfig.switches.isDaEnabled || installConfig.switches.isTaEnabled) {
+		await askCommonPrompts(webMethodsAgentValues);
+	}
+
+	return webMethodsAgentValues;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	if (installConfig.centralConfig.ampcDosaInfo.isNew && !installConfig.switches.isHelmInstall) {
+		console.log(chalk.yellow(svcAccMsg));
+	}
+
+	dockerSuccessMsg(installConfig);
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.SOFTWAREAGWEBMETHODS}`)
+	);
+};
+
+const dockerSuccessMsg = (installConfig: AgentInstallConfig) => {
+	let dockerInfo;
+	const runDaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runDaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const runTaLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runTaWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startDaLinuxMsg = '\nStart the Discovery Agent on a Linux based machine';
+	const startDaWinMsg = '\nStart the Discovery Agent on a Windows machine';
+	const startTaLinuxMsg = '\nStart the Traceability Agent on a Linux based machine';
+	const startTaWinMsg = '\nStart the Traceability Agent on a Windows machine';
+
+	if (installConfig.switches.isDaEnabled && installConfig.switches.isTaEnabled) {
+		dockerInfo = `To utilize the agents, pull the latest Docker images and run them using the appropriate supplied environment files, (${helpers.configFiles.DA_ENV_VARS} & ${helpers.configFiles.TA_ENV_VARS}):`;
+	} else if (installConfig.switches.isDaEnabled) {
+		dockerInfo = `To utilize the discovery agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.DA_ENV_VARS}):`;
+	} else {
+		dockerInfo = `To utilize the traceability agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.TA_ENV_VARS}):`;
+	}
+	console.log(chalk.whiteBright(dockerInfo), '\n');
+
+	if (installConfig.switches.isDaEnabled) {
+		const daImageVersion = `${daImage}:${installConfig.daVersion}`;
+		console.log(chalk.white('Pull the latest image of the Discovery Agent:'));
+		console.log(chalk.cyan(`docker pull ${daImageVersion}`));
+		console.log(chalk.white(isWindows ? startDaWinMsg : startDaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runDaWinMsg : runDaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${daImageVersion}`), '\n');
+	}
+	if (installConfig.switches.isTaEnabled) {
+		const taImageVersion = `${taImage}:${installConfig.taVersion}`;
+		console.log(chalk.white('Pull the latest image of the Traceability Agent:'));
+		console.log(chalk.cyan(`docker pull ${taImageVersion}`));
+		console.log(chalk.white(isWindows ? startTaWinMsg : startTaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runTaWinMsg : runTaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${taImageVersion}`), '\n');
+	}
+};
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	// Add final settings to softwareAGWebMethodsAgentValues
+	const softwareAGWebMethodsAgentValues = installConfig.gatewayConfig as SoftwareAGWebMethodsAgentValues;
+	softwareAGWebMethodsAgentValues.centralConfig = installConfig.centralConfig;
+	softwareAGWebMethodsAgentValues.traceabilityConfig = installConfig.traceabilityConfig;
+
+	console.log('Generating the configuration file(s)...');
+
+	if (installConfig.switches.isDaEnabled) {
+		writeTemplates(ConfigFiles.DAEnvVars, softwareAGWebMethodsAgentValues, helpers.softwareAGWebMethodsDAEnvVarTemplate);
+	}
+
+	if (installConfig.switches.isTaEnabled) {
+		writeTemplates(ConfigFiles.TAEnvVars, softwareAGWebMethodsAgentValues, helpers.softwareAGWebMethodsTAEnvVarTemplate);
+	}
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	generateSuccessHelpMsg(installConfig);
 };
 
 export const SoftwareAGWebMethodsInstallMethods: InstallationFlowMethods = {

--- a/src/lib/engage/utils/agents/flows/swaggerHubSaasAgents.ts
+++ b/src/lib/engage/utils/agents/flows/swaggerHubSaasAgents.ts
@@ -1,32 +1,312 @@
+import chalk from 'chalk';
+import logger from '../../../../logger.js';
+import { ApiServerClient } from '../../../clients-external/apiserverclient.js';
+import { DefinitionsManager } from '../../../results/DefinitionsManager.js';
 import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, SaaSGatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentResourceKind, AgentTypes, BundleType, CentralAgentConfig, GatewayTypeToDataPlane, GenericResource, SaaSGatewayTypes, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList, InputValidation, validateRegex } from '../../basic-prompts.js';
 import * as helpers from '../index.js';
+import * as crypto from 'crypto';
+import { DataplaneConfig } from './saasAgentsBase.js';
+
+const { log } = logger('central: install: agents: saas');
+
+class SwaggerHubDataplaneConfig extends DataplaneConfig {
+	owner: string;
+	filter: SwaggerHubFilterConfig;
+
+	constructor(owner: string, filter: SwaggerHubFilterConfig) {
+		super('SwaggerHub');
+		this.owner = owner;
+		this.filter = filter;
+	}
+}
+
+class SwaggerHubFilterConfig {
+	visibility: SwaggerHubFilterVisibility;
+	publication: SwaggerHubFilterPublication;
+
+	constructor(visibility: SwaggerHubFilterVisibility, publication: SwaggerHubFilterPublication) {
+		this.visibility = visibility;
+		this.publication = publication;
+	}
+}
+
+enum SwaggerHubFilterVisibility {
+	Both = 'Both',
+	Public = 'Public',
+	Private = 'Private'
+}
+
+enum SwaggerHubFilterPublication {
+	Both = 'Both',
+	Published = 'Published',
+	UnPublished = 'UnPublished'
+}
+
+class SaasAgentValues {
+	frequencyDA: string;
+	queueDA: boolean;
+	frequencyTA: string;
+	dataplaneConfig: DataplaneConfig;
+	centralConfig: CentralAgentConfig;
+	owner: string;
+	visibility: SwaggerHubFilterVisibility;
+	publication: SwaggerHubFilterPublication;
+
+	constructor() {
+		this.frequencyDA = '';
+		this.queueDA = false;
+		this.frequencyTA = '';
+		this.dataplaneConfig = new DataplaneConfig();
+		this.centralConfig = new CentralAgentConfig();
+		this.owner = '';
+		this.visibility = SwaggerHubFilterVisibility.Both;
+		this.publication = SwaggerHubFilterPublication.Both;
+	}
+}
+
+class SaasSwaggerHubAgentValues extends SaasAgentValues {
+	apiKey: string;
+
+	constructor() {
+		super();
+		this.apiKey = '';
+	}
+
+	getAccessData() {
+		const data = JSON.stringify({
+			apiKey: this.apiKey
+		});
+
+		return data;
+	}
+}
+
+// SwaggerHub SaaSPrompts - all SwaggerHub Saas prompts to the user for input
+const SaasPrompts = {
+	API_KEY: 'Enter the SwaggerHub API Key the agent will use',
+	ORGANIZATION_OWNER: 'Enter the SwaggerHub Organization Owner the agent will use',
+	API_VISIBILITY: 'Enter the visibility of the APIs to be discovered (Optional).',
+	API_PUBLICATION: 'Enter the publication status of APIs to be discovered (Optional).',
+	DA_FREQUENCY: 'How often should the discovery run, leave blank for integrating in CI/CD process',
+	QUEUE: 'Do you want to discover immediately after installation',
+};
 
 export const askBundleType = async (): Promise<BundleType> => {
-	return BundleType.DISCOVERY as BundleType;
+	// SwaggerHub agent has only DA
+	return BundleType.DISCOVERY;
 };
 
-export const ConfigFiles = {
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
+const askConfigType = async (): Promise<AgentConfigTypes> => {
+	return AgentConfigTypes.HOSTED;
 };
 
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
+const askForSwaggerHubCredentials = async (hostedAgentValues: SaasSwaggerHubAgentValues): Promise<SaasAgentValues> => {
+	log('gathering access details for SwaggerHub');
+
+	hostedAgentValues.apiKey = (await askInput({
+		msg: SaasPrompts.API_KEY,
+		defaultValue: hostedAgentValues.apiKey !== '' ? hostedAgentValues.apiKey : undefined,
+	})) as string;
+
+	return hostedAgentValues;
 };
 
-export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.HOSTED ],
-	})) as AgentConfigTypes;
+const validateFrequency = (): InputValidation => (input: string | number) => {
+	const val = validateRegex(
+		helpers.frequencyRegex,
+		helpers.invalidValueExampleErrMsg('frequency', '3d5h12m'),
+	)(input);
+	if (typeof val === 'string') {
+		return val;
+	}
+	const r = input.toString().match(/^(\d*)m/);
+	if (r) {
+		// only minutes
+		const mins = r[1];
+		if (parseInt(mins as string, 10) < 30) {
+			return 'Minimum frequency is 30m';
+		}
+	}
+	return true;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<object> => {
-	return {};
+const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<SaasAgentValues> => {
+	console.log('\nCONNECTION TO SwaggerHub API GATEWAY:');
+	console.log(
+		chalk.gray('The Discovery Agent needs to connect to the SwaggerHub API Gateway to discover API\'s for publishing to Amplify Central')
+	);
+
+	// DeploymentType
+	let hostedAgentValues: SaasAgentValues = new SaasAgentValues();
+
+	if (installConfig.gatewayType === SaaSGatewayTypes.SWAGGERHUB) {
+		// SwaggerHub connection details
+		hostedAgentValues = new SaasSwaggerHubAgentValues();
+		hostedAgentValues = await askForSwaggerHubCredentials(hostedAgentValues as SaasSwaggerHubAgentValues);
+	}
+
+	// Ask to queue discovery now
+	log('getting the frequency and if the agent should run now');
+	console.log(
+		chalk.gray('\n00d00h00m format, where 30m = 30 minutes, 1h = 1 hour, 7d = 7 days, and 7d1h30m = 7 days 1 hour and 30 minutes. Minimum of 30m.')
+	);
+	hostedAgentValues.frequencyDA = await askInput({
+		msg: SaasPrompts.DA_FREQUENCY,
+		validate: validateFrequency(),
+		allowEmptyInput: true,
+	}) as string;
+
+	hostedAgentValues.queueDA = await askList({
+		msg: SaasPrompts.QUEUE,
+		default: YesNo.No,
+		choices: YesNoChoices,
+	}) as YesNo === YesNo.Yes;
+
+	// get swaggerhub organization owner
+	hostedAgentValues.owner = (await askInput({
+		msg: SaasPrompts.ORGANIZATION_OWNER,
+		defaultValue: hostedAgentValues.owner !== '' ? hostedAgentValues.owner : undefined,
+	})) as string;
+
+	// get visility of APIs to be discovered
+	hostedAgentValues.visibility = (await askList({
+		msg: SaasPrompts.API_VISIBILITY,
+		default: SwaggerHubFilterVisibility.Both,
+		choices: [
+			{ name: SwaggerHubFilterVisibility.Both, value: SwaggerHubFilterVisibility.Both },
+			{ name: SwaggerHubFilterVisibility.Public, value: SwaggerHubFilterVisibility.Public },
+			{ name: SwaggerHubFilterVisibility.Private, value: SwaggerHubFilterVisibility.Private },
+		],
+	})) as SwaggerHubFilterVisibility;
+
+	// get publication status of APIs to be discovered
+	hostedAgentValues.publication = (await askList({
+		msg: SaasPrompts.API_PUBLICATION,
+		default: SwaggerHubFilterPublication.Both,
+		choices: [
+			{ name: SwaggerHubFilterPublication.Both, value: SwaggerHubFilterPublication.Both },
+			{ name: SwaggerHubFilterPublication.Published, value: SwaggerHubFilterPublication.Published },
+			{ name: SwaggerHubFilterPublication.UnPublished, value: SwaggerHubFilterPublication.UnPublished },
+		],
+	})) as SwaggerHubFilterPublication;
+
+	return hostedAgentValues;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const generateOutput = async (installConfig: AgentInstallConfig): Promise<string> => {
+	return `Install complete of hosted agent for ${installConfig.gatewayType} region`;
+};
+
+const createEncryptedAccessData = async (hostedAgentValues: SaasSwaggerHubAgentValues, dataplaneRes: GenericResource): Promise<string> => {
+	// grab key from data plane resource
+	const key = dataplaneRes.security?.encryptionKey  || '';
+	const hash = dataplaneRes.security?.encryptionHash || '';
+
+	if (key === '' || hash === '') {
+		throw Error('cannot encrypt access data as the encryption key info was incomplete');
+	}
+	console.log(hostedAgentValues.getAccessData());
+	const encData = crypto.publicEncrypt({
+		key: key,
+		padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+		oaepHash: hash,
+	},
+	Buffer.from(hostedAgentValues.getAccessData())
+	);
+
+	return encData.toString('base64');
+};
+
+const completeInstall = async (installConfig: AgentInstallConfig, apiServerClient?: ApiServerClient, defsManager?: DefinitionsManager): Promise<void> => {
+	/**
+	 * Create agent resources
+	 */
+	console.log('\n');
+	const swaggerHubAgentValues = installConfig.gatewayConfig as SaasSwaggerHubAgentValues;
+
+	// create the environment, if necessary
+	installConfig.centralConfig.environment = installConfig.centralConfig.ampcEnvInfo.isNew
+		? await helpers.createByResourceType(
+			apiServerClient as ApiServerClient,
+			defsManager as DefinitionsManager,
+			installConfig.centralConfig.ampcEnvInfo.name,
+			'Environment',
+			'env',
+			{
+				axwayManaged: installConfig.centralConfig.axwayManaged,
+				production: installConfig.centralConfig.production,
+			}
+		)
+		: installConfig.centralConfig.ampcEnvInfo.name;
+
+	if (installConfig.gatewayType === SaaSGatewayTypes.SWAGGERHUB) {
+		swaggerHubAgentValues.dataplaneConfig
+			= new SwaggerHubDataplaneConfig((swaggerHubAgentValues as SaasSwaggerHubAgentValues).owner,
+				new SwaggerHubFilterConfig((swaggerHubAgentValues as SaasSwaggerHubAgentValues).visibility, (swaggerHubAgentValues as SaasSwaggerHubAgentValues).publication));
+	}
+
+	// create the data plane resource
+	const dataplaneRes = await helpers.createNewDataPlaneResource(
+		apiServerClient as ApiServerClient,
+		defsManager as DefinitionsManager,
+		installConfig.centralConfig.environment,
+		GatewayTypeToDataPlane[installConfig.gatewayType],
+		swaggerHubAgentValues.dataplaneConfig,
+	);
+	// create data plane secret resource
+	try {
+		await helpers.createNewDataPlaneSecretResource(
+			apiServerClient as ApiServerClient,
+			defsManager as DefinitionsManager,
+			installConfig.centralConfig.environment,
+			GatewayTypeToDataPlane[installConfig.gatewayType],
+			dataplaneRes.name,
+			await createEncryptedAccessData(swaggerHubAgentValues, dataplaneRes),
+		);
+	} catch (_error) {
+		console.log(
+			chalk.redBright('rolling back installation. Please check the credential data before re-running install')
+		);
+
+		if (installConfig.centralConfig.ampcEnvInfo.isNew) {
+			await helpers.deleteByResourceType(
+				apiServerClient as ApiServerClient,
+				defsManager as DefinitionsManager,
+				installConfig.centralConfig.ampcEnvInfo.name,
+				'Environment',
+				'env',
+			);
+		} else {
+			await helpers.deleteByResourceType(
+				apiServerClient as ApiServerClient,
+				defsManager as DefinitionsManager,
+				dataplaneRes.name,
+				'Dataplane',
+				'dp',
+				installConfig.centralConfig.environment,
+			);
+		}
+		return;
+	}
+
+	// create discovery agent resource
+	installConfig.centralConfig.daAgentName = await helpers.createNewAgentResource(
+		apiServerClient as ApiServerClient,
+		defsManager as DefinitionsManager,
+		installConfig.centralConfig.environment,
+		GatewayTypeToDataPlane[installConfig.gatewayType],
+		AgentResourceKind.da,
+		AgentTypes.da,
+		installConfig.centralConfig.ampcTeamName,
+		GatewayTypeToDataPlane[installConfig.gatewayType] + ' Discovery Agent',
+		dataplaneRes.name,
+		swaggerHubAgentValues.frequencyDA,
+		swaggerHubAgentValues.queueDA,
+	);
+
+	console.log(await generateOutput(installConfig));
 };
 
 export const SwaggerHubSaaSInstallMethods: InstallationFlowMethods = {
@@ -34,7 +314,7 @@ export const SwaggerHubSaaSInstallMethods: InstallationFlowMethods = {
 	GetDeploymentType: askConfigType,
 	AskGatewayQuestions: gatewayConnectivity,
 	FinalizeGatewayInstall: completeInstall,
-	ConfigFiles: Object.values(ConfigFiles),
+	ConfigFiles: [],
 	AgentNameMap: {
 		[AgentTypes.da]: AgentNames.SWAGGERHUB_DA,
 	},

--- a/src/lib/engage/utils/agents/flows/traceableAgents.ts
+++ b/src/lib/engage/utils/agents/flows/traceableAgents.ts
@@ -1,35 +1,284 @@
-import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
+import chalk from 'chalk';
+import { ApiServerClient } from '../../../clients-external/apiserverclient.js';
+import { DefinitionsManager } from '../../../results/DefinitionsManager.js';
+import { InstallationFlowMethods, svcAccMsg } from '../../../services/install-service.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, GenericResource, PublicDockerRepoBaseUrl, TraceableRegionType, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList } from '../../basic-prompts.js';
+import { AgentHelmInfo, helmImageSecretInfo, helmInstallInfo, isWindows, writeTemplates } from '../../utils.js';
 import { TraceableAgentValues } from '../index.js';
 import * as helpers from '../index.js';
+import { kubectl } from '../kubectl.js';
 
-export const askBundleType = async (): Promise<BundleType> => {
-	return BundleType.TRACEABILITY as BundleType;
-};
+const caImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.TRACEABLE_CA}`;
+export const amplifyAgentsNs = 'amplify-agents';
 
+// ConfigFiles - all the config file that are used in the setup
 export const ConfigFiles = {
 	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
+	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`
 };
 
+// TraceablePrompts - prompts for user inputs
 const prompts = {
 	configTypeMsg: 'Select the mode of installation',
+	agentNamespace: 'Enter the namespace to use for the Amplify Traceable Agents',
+	enterToken: 'Enter the token that the agent will use',
+	enterRegion: 'Enter the region that the agent will use',
+	enterEnvironments: 'Enter a Traceable environment',
+	enterMoreEnvironments: 'Do you want to enter another mapping?',
+	selectCentralMappingEnvironment: 'Select an Engage environment to map to the provided Traceable environment',
+	environmentsDescription: 'Configure a mapping of Traceable environment to Engage environment that the agent will use',
+};
+
+export const askBundleType = async (): Promise<BundleType> => {
+	return  BundleType.TRACEABILITY as BundleType;
 };
 
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
 	return (await askList({
 		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
+		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM ],
 	})) as AgentConfigTypes;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<TraceableAgentValues> => {
-	const values: TraceableAgentValues = new TraceableAgentValues();
-	return values;
+//
+// Questions for the configuration of Traceable agent
+//
+const askToken = async (): Promise<string> =>
+	(await askInput({
+		msg: prompts.enterToken,
+		allowEmptyInput: false,
+	})) as string;
+
+export const askTraceableRegion = async (): Promise<TraceableRegionType> => {
+	return (await askList({
+		msg: prompts.enterRegion,
+		choices: Object.entries(TraceableRegionType).reduce((accumulator, curr) => {
+			return accumulator.concat({
+				name: curr[0],
+				value: curr[1] as string,
+			});
+		}, [] as { name: string; value: string }[]),
+		default: TraceableRegionType.US,
+	})) as TraceableRegionType;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const askEnvironments = async (centralEnvs: GenericResource[], traceableAgentValues: TraceableAgentValues, excludeEnvironment?: string): Promise<void> => {
+	// Filter out the already-selected agent installation environment
+	if (excludeEnvironment) {
+		centralEnvs = centralEnvs.filter(env => env.name !== excludeEnvironment);
+	}
+
+	// If no central environments are available, exit the installation
+	if (centralEnvs.length === 0) {
+		console.log(chalk.red('Installation cannot proceed: No Engage environments are available for mapping.'));
+		console.log(chalk.yellow('Please create at least one Engage environment before installing the Traceable agent.'));
+		console.log(chalk.gray('You can create an environment using: axway engage create environment'));
+		process.exit(1);
+	}
+
+	let askEnvs = true;
+	const envs = [];
+	const mappedCentralEnvs = [];
+	console.log(chalk.gray(prompts.environmentsDescription));
+	while (askEnvs) {
+		const env = (await askInput({
+			msg: prompts.enterEnvironments,
+			allowEmptyInput: true,
+		})) as string;
+
+		if (envs.length === 0 && (!env || env.toString().trim() === '')) {
+			break;
+		}
+
+		if (env && env.toString().trim() !== '') {
+			envs.push(env);
+		}
+		const centralMappingEnv = await askList({
+			msg: prompts.selectCentralMappingEnvironment,
+			choices: centralEnvs.map((e) => e.name),
+		});
+
+		if (centralMappingEnv && centralMappingEnv.toString().trim() !== '') {
+			mappedCentralEnvs.push(centralMappingEnv);
+		}
+		// Remove the selected environment from available choices for next iteration
+		centralEnvs = centralEnvs.filter(env => env.name !== centralMappingEnv);
+
+		// Only ask to continue if there are remaining central environments
+		if (centralEnvs.length > 0) {
+			askEnvs = await askList({
+				msg: prompts.enterMoreEnvironments,
+				default: YesNo.No,
+				choices: YesNoChoices,
+			}) === YesNo.Yes;
+		} else {
+			askEnvs = false; // Auto-stop when no environments remain
+		}
+	}
+	traceableAgentValues.environments = envs;
+	traceableAgentValues.centralEnvironments = mappedCentralEnvs;
+};
+
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<TraceableAgentValues> => {
+	const traceableAgentValues: TraceableAgentValues = new TraceableAgentValues();
+
+	if (installConfig.switches.isHelmInstall) {
+		console.log(
+			chalk.gray('The Amplify Traceable Agent needs to be deployed to your Kubernetes cluster to discover APIs for publishing to Amplify Central.')
+		);
+		const { error } = await kubectl.isInstalled();
+		if (error) {
+			throw new Error(
+				`Kubectl is required to fill out the following prompts. It appears to be missing or misconfigured.\n${error}`
+			);
+		}
+		traceableAgentValues.namespace = await helpers.askNamespace(prompts.agentNamespace, amplifyAgentsNs);
+	}
+	if (installConfig.switches.isDockerInstall) {
+		console.log('\nCONNECTION TO TRACEABLE API GATEWAY:');
+		console.log(
+			chalk.gray('The Discovery Agent needs to connect to the Traceable API Gateway to discover API\'s for publishing to Amplify Central.')
+		);
+	}
+	traceableAgentValues.traceableToken = await askToken();
+	traceableAgentValues.traceableRegion = await askTraceableRegion();
+	await helpers.getCentralEnvironments(installConfig.centralConfig.apiServerClient as ApiServerClient, installConfig.centralConfig.definitionManager as DefinitionsManager)
+		.then(async envs => {
+			// eslint-disable-next-line promise/always-return
+			if (envs) {
+			// Pass the already-selected agent installation environment to exclude it from mapping choices
+				const agentInstallEnv = installConfig.centralConfig.ampcEnvInfo?.name;
+				await askEnvironments(envs, traceableAgentValues, agentInstallEnv);
+			}
+		});
+
+	return traceableAgentValues;
+};
+
+const dockerSuccessMsg = (installConfig: AgentInstallConfig) => {
+	let dockerInfo;
+	const runAgentLinuxMsg = `docker run -it --env-file ${helpers.pwd}/${helpers.configFiles.AGENT_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runAgentWinMsg = `docker run -it --env-file ${helpers.pwdWin}/${helpers.configFiles.AGENT_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startAgentLinuxMsg = '\nStart the Traceable Agent on a Linux based machine';
+	const startAgentWinMsg = '\nStart the Traceable Agent on a Windows machine';
+
+	if (installConfig.switches.isTaEnabled) {
+		dockerInfo = `To utilize the agent, pull the latest Docker image and run it using the appropriate supplied environment file, (${helpers.configFiles.AGENT_ENV_VARS}):`;
+		console.log(chalk.whiteBright(dockerInfo), '\n');
+		const caImageVersion = `${caImage}:${installConfig.taVersion}`;
+		console.log(chalk.white('Pull the latest image of the Agent:'));
+		console.log(chalk.cyan(`docker pull ${caImageVersion}`));
+		console.log(chalk.white(isWindows ? startAgentWinMsg : startAgentLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runAgentWinMsg : runAgentLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${caImageVersion}`), '\n');
+	}
+};
+
+const helmSuccessMsg = (namespace: string) => {
+	console.log(`Traceable Agent override file has been placed at ${process.cwd()}/${ConfigFiles.helmOverride}`);
+	helmImageSecretInfo(namespace);
+
+	const agentHelmInfo = new Set<AgentHelmInfo>();
+	agentHelmInfo.add({
+		helmReleaseName: 'traceable-agent',
+		helmChartName: ' axway/traceable-agent',
+		overrideFileName: ConfigFiles.helmOverride,
+		imageSecretOverrides: '--set image.pullSecret=<image-pull-secret-name>' });
+
+	helmInstallInfo(
+		'Traceable',
+		namespace,
+		agentHelmInfo
+	);
+};
+
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	const traceableAgentValues = installConfig.gatewayConfig as TraceableAgentValues;
+	const configType = installConfig.deploymentType;
+	if (installConfig.centralConfig.ampcDosaInfo.isNew && !installConfig.switches.isHelmInstall) {
+		console.log(chalk.yellow(svcAccMsg));
+	}
+	if (configType === AgentConfigTypes.DOCKERIZED) {
+		dockerSuccessMsg(installConfig);
+	} else if (configType === AgentConfigTypes.HELM) {
+		helmSuccessMsg(
+			traceableAgentValues.namespace.name
+		);
+	}
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.TRACEABLE}`)
+	);
+};
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	// Add final settings to TraceableAgentValues
+	const traceableAgentValues = installConfig.gatewayConfig as TraceableAgentValues;
+	traceableAgentValues.centralConfig = installConfig.centralConfig;
+	traceableAgentValues.traceabilityConfig = installConfig.traceabilityConfig;
+
+	if (installConfig.switches.isHelmInstall) {
+		traceableAgentValues.traceableSecret = helpers.amplifyAgentsCredsSecret;
+		traceableAgentValues.agentKeysSecret = helpers.amplifyAgentsKeysSecret;
+		if (traceableAgentValues.namespace.isNew) {
+			await helpers.createNamespace(traceableAgentValues.namespace.name);
+		}
+		await helpers.createSecret(traceableAgentValues.namespace.name, helpers.amplifyAgentsKeysSecret, async () => {
+			if (installConfig.centralConfig.ampcDosaInfo.isNew) {
+				console.log(
+					chalk.yellow(
+						`The secret '${helpers.amplifyAgentsKeysSecret}' will be created with the same "private_key.pem" and "public_key.pem" that was auto generated to create the Service Account.`
+					)
+				);
+			}
+
+			await helpers.createAmplifyAgentKeysSecret(
+				traceableAgentValues.namespace.name,
+				helpers.amplifyAgentsKeysSecret,
+				'publicKey',
+				traceableAgentValues.centralConfig.dosaAccount.publicKey,
+				'privateKey',
+				traceableAgentValues.centralConfig.dosaAccount.privateKey
+			);
+		});
+		await helpers.createSecret(traceableAgentValues.namespace.name, helpers.amplifyAgentsCredsSecret, async () => {
+			await createTraceableCredsSecret(
+				traceableAgentValues.namespace.name,
+				helpers.amplifyAgentsCredsSecret,
+				traceableAgentValues.traceableToken,
+			);
+		});
+	}
+
+	console.log('Generating the configuration file(s)...');
+	if (installConfig.switches.isDockerInstall) {
+		if (installConfig.switches.isTaEnabled) {
+			writeTemplates(ConfigFiles.agentEnvVars, traceableAgentValues, helpers.traceableEnvVarTemplate);
+		}
+	} else if (installConfig.switches.isHelmInstall) {
+		writeTemplates(ConfigFiles.helmOverride, traceableAgentValues, helpers.traceableHelmOverrideTemplate);
+	}
+
+	generateSuccessHelpMsg(installConfig);
+};
+
+const createTraceableCredsSecret = async (
+	namespace: string,
+	secretName: string,
+	token: string,
+): Promise<void> => {
+	const { error } = await kubectl.create(
+		'secret',
+		`-n ${namespace} generic ${secretName} \
+		--from-literal=token=${token} `
+	);
+	if (error) {
+		throw Error(error);
+	}
+	console.log(`Created ${secretName} in the ${namespace} namespace.`);
 };
 
 export const TraceableInstallMethods: InstallationFlowMethods = {

--- a/src/lib/engage/utils/agents/flows/traceableSaasAgents.ts
+++ b/src/lib/engage/utils/agents/flows/traceableSaasAgents.ts
@@ -1,34 +1,303 @@
+import chalk from 'chalk';
+import logger from '../../../../logger.js';
+import { ApiServerClient } from '../../../clients-external/apiserverclient.js';
+import { DefinitionsManager } from '../../../results/DefinitionsManager.js';
 import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, SaaSGatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
-import { TraceableAgentValues } from '../index.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentResourceKind, AgentTypes, BundleType, CentralAgentConfig, GatewayTypes, GatewayTypeToDataPlane, GenericResource, SaaSGatewayTypes, TraceableRegionType, YesNo, YesNoChoices } from '../../../types.js';
+import { askInput, askList } from '../../basic-prompts.js';
 import * as helpers from '../index.js';
+import * as crypto from 'crypto';
+import { DataplaneConfig } from './saasAgentsBase.js';
+
+const { log } = logger('engage: install: agents: Traceable');
+
+class TraceableDataplaneConfig extends DataplaneConfig {
+	region: string;
+	environments: TraceableEnvironments[];
+	constructor(region: string, environments: TraceableEnvironments[]) {
+		super('Traceable');
+		this.region = region;
+		this.environments = environments;
+	}
+}
+
+class TraceableEnvironments {
+	traceable: string;
+	environment: string;
+
+	constructor(traceable: string, environment: string) {
+		this.traceable = traceable;
+		this.environment = environment;
+	}
+}
+
+class SaasAgentValues {
+	dataplaneConfig: DataplaneConfig;
+	centralConfig: CentralAgentConfig;
+
+	constructor() {
+		this.dataplaneConfig = new DataplaneConfig();
+		this.centralConfig = new CentralAgentConfig();
+	}
+
+	getAccessData() {
+		return '';
+	}
+}
+
+class SaasTraceableAgentValues extends SaasAgentValues {
+	traceableToken: string;
+	traceableRegion: TraceableRegionType;
+	environments: string[];
+	centralEnvironments: string[];
+
+	constructor() {
+		super();
+		this.traceableToken = '';
+		this.traceableRegion = TraceableRegionType.US;
+		this.environments = [];
+		this.centralEnvironments = [];
+
+	}
+
+	override getAccessData() {
+		const data = JSON.stringify({
+			token: this.traceableToken,
+		});
+
+		return data;
+	}
+}
+
+// TraceableSaaSPrompts - all Traceable Saas prompts to the user for input
+const SaasPrompts = {
+	configTypeMsg: 'Select the mode of installation',
+	agentNamespace: 'Enter the namespace to use for the Amplify Traceable Agents',
+	enterToken: 'Enter the token that the agent will use',
+	enterRegion: 'Enter the region that the agent will use',
+	enterEnvironments: 'Enter a Traceable environment',
+	enterMoreEnvironments: 'Do you want to enter another mapping?',
+	selectCentralMappingEnvironment: 'Select an Engage environment to map to the provided Traceable environment',
+	environmentsDescription: 'Configure a mapping of Traceable environment to Engage environment that the agent will use',
+};
 
 export const askBundleType = async (): Promise<BundleType> => {
-	return BundleType.TRACEABILITY as BundleType;
+	return  BundleType.TRACEABILITY as BundleType;
 };
 
-export const ConfigFiles = {
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
+const askConfigType = async (): Promise<AgentConfigTypes> => {
+	return AgentConfigTypes.HOSTED;
 };
 
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
+const askEnvironments = async (centralEnvs: GenericResource[], hostedAgentValues: SaasTraceableAgentValues, excludeEnvironment?: string): Promise<void> => {
+	// Filter out the already-selected agent installation environment
+	if (excludeEnvironment) {
+		centralEnvs = centralEnvs.filter(env => env.name !== excludeEnvironment);
+	}
+
+	let askEnvs = true;
+	const envs = [];
+	const mappedCentralEnvs = [];
+	console.log(chalk.gray(SaasPrompts.environmentsDescription));
+	while (askEnvs) {
+		const env = (await askInput({
+			msg: SaasPrompts.enterEnvironments,
+			allowEmptyInput: true,
+		})) as string;
+
+		if (envs.length === 0 && (!env || env.toString().trim() === '')) {
+			break;
+		}
+
+		if (env && env.toString().trim() !== '') {
+			envs.push(env);
+		}
+		const centralMappingEnv = await askList({
+			msg: SaasPrompts.selectCentralMappingEnvironment,
+			choices: centralEnvs.map((e) => e.name),
+		});
+
+		if (centralMappingEnv && centralMappingEnv.toString().trim() !== '') {
+			mappedCentralEnvs.push(centralMappingEnv);
+		}
+		centralEnvs = centralEnvs.filter(env => env.name !== centralMappingEnv);
+
+		// Only ask if they want to continue if there are still environments available to map
+		if (centralEnvs.length > 0) {
+			askEnvs = await askList({
+				msg: SaasPrompts.enterMoreEnvironments,
+				default: YesNo.No,
+				choices: YesNoChoices,
+			}) === YesNo.Yes;
+		} else {
+			askEnvs = false;
+		}
+	}
+	hostedAgentValues.environments = envs;
+	hostedAgentValues.centralEnvironments = mappedCentralEnvs;
 };
 
-export const askConfigType = async (): Promise<AgentConfigTypes> => {
+//
+// Questions for the configuration of Traceable agent
+//
+const askToken = async (): Promise<string> =>
+	(await askInput({
+		msg: SaasPrompts.enterToken,
+		allowEmptyInput: false,
+	})) as string;
+
+export const askTraceableRegion = async (): Promise<TraceableRegionType> => {
 	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.HOSTED ],
-	})) as AgentConfigTypes;
+		msg: SaasPrompts.enterRegion,
+		choices: Object.entries(TraceableRegionType).reduce((accumulator, curr) => {
+			return accumulator.concat({
+				name: curr[0],
+				value: curr[1] as string,
+			});
+		}, [] as { name: string; value: string }[]),
+		default: TraceableRegionType.US,
+	})) as TraceableRegionType;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<TraceableAgentValues> => {
-	const values: TraceableAgentValues = new TraceableAgentValues();
-	return values;
+const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<SaasAgentValues> => {
+	console.log('\nCONNECTION TO TRACEABLE API GATEWAY:');
+	// DeploymentType
+	let hostedAgentValues: SaasTraceableAgentValues = new SaasTraceableAgentValues();
+
+	if (installConfig.gatewayType === SaaSGatewayTypes.TRACEABLE) {
+		log('gathering access details for traceable');
+
+		// Traceable connection details
+		hostedAgentValues = new SaasTraceableAgentValues();
+		hostedAgentValues.traceableToken = await askToken();
+		hostedAgentValues.traceableRegion = await askTraceableRegion();
+
+		const centralEnvs = await helpers.getCentralEnvironments(installConfig.centralConfig.apiServerClient as ApiServerClient, installConfig.centralConfig.definitionManager as DefinitionsManager);
+		// Pass the already-selected agent installation environment to exclude it from mapping choices
+		const agentInstallEnv = installConfig.centralConfig.ampcEnvInfo?.name;
+		await askEnvironments(centralEnvs!, hostedAgentValues, agentInstallEnv);
+	}
+
+	return hostedAgentValues;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const generateOutput = async (installConfig: AgentInstallConfig): Promise<string> => {
+	return `Install complete of hosted agent for ${installConfig.gatewayType} region`;
+};
+
+const createEncryptedAccessData = async (hostedAgentValues: SaasTraceableAgentValues, dataplaneRes: GenericResource): Promise<string> => {
+	// grab key from data plane resource
+	const key = dataplaneRes.security?.encryptionKey  || '';
+	const hash = dataplaneRes.security?.encryptionHash || '';
+
+	if (key === '' || hash === '') {
+		throw Error('cannot encrypt access data as the encryption key info was incomplete');
+	}
+
+	const accessData = hostedAgentValues.getAccessData();
+
+	const encData = crypto.publicEncrypt({
+		key: key,
+		padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+		oaepHash: hash,
+	},
+	new Uint8Array(Buffer.from(accessData, 'utf8'))
+	);
+
+	return encData.toString('base64');
+};
+
+const completeInstall = async (installConfig: AgentInstallConfig, apiServerClient?: ApiServerClient, defsManager?: DefinitionsManager): Promise<void> => {
+	/**
+     * Create agent resources
+     */
+	console.log('\n');
+	const traceableAgentValues = installConfig.gatewayConfig as SaasTraceableAgentValues;
+
+	// create the environment, if necessary
+	installConfig.centralConfig.environment = installConfig.centralConfig.ampcEnvInfo.isNew
+		? await helpers.createByResourceType(
+			apiServerClient as ApiServerClient,
+			defsManager as DefinitionsManager,
+			installConfig.centralConfig.ampcEnvInfo.name,
+			'Environment',
+			'env',
+			{
+				axwayManaged: installConfig.centralConfig.axwayManaged,
+				production: installConfig.centralConfig.production,
+			}
+		)
+		: installConfig.centralConfig.ampcEnvInfo.name;
+
+	if (installConfig.gatewayType === GatewayTypes.TRACEABLE) {
+		const traceableEnvObjs = (traceableAgentValues.environments || []).map((env, idx) =>
+			new TraceableEnvironments(env, traceableAgentValues.centralEnvironments[idx])
+		);
+		traceableAgentValues.dataplaneConfig = new TraceableDataplaneConfig(
+			traceableAgentValues.traceableRegion,
+			traceableEnvObjs
+		);
+	}
+
+	// create the data plane resource
+	const dataplaneRes = await helpers.createNewDataPlaneResource(
+		apiServerClient as ApiServerClient,
+		defsManager as DefinitionsManager,
+		installConfig.centralConfig.environment,
+		GatewayTypeToDataPlane[installConfig.gatewayType],
+		traceableAgentValues.dataplaneConfig,
+	);
+	// create data plane secret resource
+	try {
+		await helpers.createNewDataPlaneSecretResource(
+			apiServerClient as ApiServerClient,
+			defsManager as DefinitionsManager,
+			installConfig.centralConfig.environment,
+			GatewayTypeToDataPlane[installConfig.gatewayType],
+			dataplaneRes.name,
+			await createEncryptedAccessData(traceableAgentValues, dataplaneRes),
+		);
+	} catch (error) {
+		log(error);
+		console.log(
+			chalk.redBright('rolling back installation. Please check the credential data before re-running install')
+		);
+
+		if (installConfig.centralConfig.ampcEnvInfo.isNew) {
+			await helpers.deleteByResourceType(
+				apiServerClient as ApiServerClient,
+				defsManager as DefinitionsManager,
+				installConfig.centralConfig.ampcEnvInfo.name,
+				'Environment',
+				'env',
+			);
+		} else {
+			await helpers.deleteByResourceType(
+				apiServerClient as ApiServerClient,
+				defsManager as DefinitionsManager,
+				dataplaneRes.name,
+				'Dataplane',
+				'dp',
+				installConfig.centralConfig.environment,
+			);
+		}
+		return;
+	}
+
+	// create compliance agent resource
+	installConfig.centralConfig.taAgentName = await helpers.createNewAgentResource(
+		apiServerClient as ApiServerClient,
+		defsManager as DefinitionsManager,
+		installConfig.centralConfig.environment,
+		GatewayTypeToDataPlane[installConfig.gatewayType],
+		AgentResourceKind.ca,
+		AgentTypes.ca,
+		installConfig.centralConfig.ampcTeamName,
+		GatewayTypeToDataPlane[installConfig.gatewayType] + ' Compliance Agent',
+		dataplaneRes.name
+	);
+
+	console.log(await generateOutput(installConfig));
 };
 
 export const TraceableSaaSInstallMethods: InstallationFlowMethods = {
@@ -36,9 +305,9 @@ export const TraceableSaaSInstallMethods: InstallationFlowMethods = {
 	GetDeploymentType: askConfigType,
 	AskGatewayQuestions: gatewayConnectivity,
 	FinalizeGatewayInstall: completeInstall,
-	ConfigFiles: Object.values(ConfigFiles),
+	ConfigFiles: [],
 	AgentNameMap: {
 		[AgentTypes.ca]: AgentNames.TRACEABLE_CA,
 	},
-	GatewayDisplay: SaaSGatewayTypes.TRACEABLE,
+	GatewayDisplay: GatewayTypes.TRACEABLE,
 };

--- a/src/lib/engage/utils/agents/flows/wso2Agents.ts
+++ b/src/lib/engage/utils/agents/flows/wso2Agents.ts
@@ -1,38 +1,168 @@
-import { InstallationFlowMethods } from '../../../services/install-service.js';
-import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BundleType, GatewayTypes } from '../../../types.js';
-import { askList } from '../../basic-prompts.js';
-import { WSO2AgentValues } from '../templates/wso2Templates.js';
+import { InstallationFlowMethods, svcAccMsg } from '../../../services/install-service.js';
+import { AgentConfigTypes, AgentInstallConfig, AgentNames, AgentTypes, BasePaths, BundleType, GatewayTypes, PublicDockerRepoBaseUrl } from '../../../types.js';
+import { askInput, askList, validateRegex } from '../../basic-prompts.js';
+import { WSO2AgentValues, wso2DAEnvVarTemplate, wso2TAEnvVarTemplate } from '../templates/wso2Templates.js';
 import * as helpers from '../index.js';
+import chalk from 'chalk';
+import { isWindows, writeTemplates } from '../../utils.js';
+
+const daImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.WSO2_DA}`;
+const taImage = `${PublicDockerRepoBaseUrl}${BasePaths.DockerAgentPublicRepo}/${AgentNames.WSO2_TA}`;
+
+export const defaultLogFiles = '/group-*_instance-*.log';
+
+// ConfigFiles - all the config file that are used in the setup
+export const ConfigFiles = {
+	DAEnvVars: `${helpers.configFiles.DA_ENV_VARS}`,
+	TAEnvVars: `${helpers.configFiles.TA_ENV_VARS}`,
+	WSO2DABinaryFile: 'discovery_agent',
+	WSO2DAYaml: 'discovery_agent.yml',
+	WSO2TABinaryFile: 'traceability_agent',
+	WSO2TAYaml: 'traceability_agent.yml',
+};
+
+// WSO2Prompts - prompts for user inputs
+const WSO2Prompts = {
+	configTypeMsg: 'Select the mode of installation',
+	enterWSO2BaseURL: 'Enter the WSO2 baseURL',
+	enterWSO2ClientID: 'Enter the WSO2 ClientID',
+	enterWSO2ClientSecret: 'Enter the WSO2 ClientSecret',
+};
 
 export const askBundleType = async (): Promise<BundleType> => {
 	return (await askList({
-		msg: 'Select the type of agent(s) you want to install',
+		msg: helpers.agentMessages.selectAgentType,
 		choices: [ BundleType.ALL_AGENTS, BundleType.DISCOVERY, BundleType.TRACEABILITY ],
 	})) as BundleType;
 };
 
-export const ConfigFiles = {
-	helmOverride: 'agent-overrides.yaml',
-	agentEnvVars: `${helpers.configFiles.AGENT_ENV_VARS}`,
-};
-
-const prompts = {
-	configTypeMsg: 'Select the mode of installation',
-};
-
 export const askConfigType = async (): Promise<AgentConfigTypes> => {
-	return (await askList({
-		msg: prompts.configTypeMsg,
-		choices: [ AgentConfigTypes.DOCKERIZED, AgentConfigTypes.HELM, AgentConfigTypes.BINARIES ],
-	})) as AgentConfigTypes;
+	return AgentConfigTypes.DOCKERIZED;
 };
 
-export const gatewayConnectivity = async (_installConfig: AgentInstallConfig): Promise<WSO2AgentValues> => {
-	const values: WSO2AgentValues = new WSO2AgentValues();
-	return values;
+//
+// Questions for the configuration of WSO2 agents
+//
+
+const askWSO2BaseURL = async (): Promise<string> =>
+	(await askInput({
+		msg: WSO2Prompts.enterWSO2BaseURL,
+		allowEmptyInput: false,
+		validate: validateRegex(
+			helpers.WSO2RegexPatterns.wso2BaseURLRegex,
+			helpers.invalidValueExampleErrMsg('WSO2_BASEURL', 'https://www.wso2domain.com')
+		),
+	})) as string;
+
+const askWSO2ClientID = async (): Promise<string> =>
+	(await askInput({
+		msg: WSO2Prompts.enterWSO2ClientID,
+	})) as string;
+
+const askWSO2ClientSecret = async (): Promise<string> =>
+	(await askInput({
+		msg: WSO2Prompts.enterWSO2ClientSecret,
+	})) as string;
+
+export const gatewayConnectivity = async (installConfig: AgentInstallConfig): Promise<WSO2AgentValues> => {
+	const agentValues: WSO2AgentValues = new WSO2AgentValues();
+	console.log('\nCONNECTION TO WSO2:');
+	console.log(
+		chalk.gray(
+			'The discovery agent needs to connect to the WSO2 API Manager to discover API\'s for publishing to Amplify.\nThe traceability agent will serve as the trace logging service that will receive WSO2 tracing payloads. These will be forwarded to the Business Insights. There are no specific WSO2 Traceability agent variables.\n'
+		)
+	);
+
+	if (installConfig.switches.isDaEnabled) {
+		console.log(chalk.gray('\nDiscovery Agent Configuration\n'));
+
+		await askDiscoveryPrompts(agentValues);
+	}
+
+	return agentValues;
 };
 
-export const completeInstall = async (_installConfig: AgentInstallConfig): Promise<void> => {
+const generateSuccessHelpMsg = (installConfig: AgentInstallConfig) => {
+	if (installConfig.centralConfig.ampcDosaInfo.isNew && !installConfig.switches.isHelmInstall) {
+		console.log(chalk.yellow(svcAccMsg));
+	}
+
+	dockerSuccessMsg(installConfig);
+
+	console.log(
+		chalk.gray(`\nAdditional information about agent features can be found here:\n${helpers.agentsDocsUrl.WSO2}`)
+	);
+};
+
+const dockerSuccessMsg = (installConfig: AgentInstallConfig) => {
+	let dockerInfo;
+	const runDaLinuxMsg = `docker run --env-file ${helpers.pwd}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runDaWinMsg = `docker run --env-file ${helpers.pwdWin}/${helpers.configFiles.DA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const runTaLinuxMsg = `docker run --env-file ${helpers.pwd}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwd}:/keys ${helpers.eolChar}`;
+	const runTaWinMsg = `docker run --env-file ${helpers.pwdWin}/${helpers.configFiles.TA_ENV_VARS} -v ${helpers.pwdWin}:/keys ${helpers.eolCharWin}`;
+	const startDaLinuxMsg = '\nStart the Discovery Agent on a Linux based machine';
+	const startDaWinMsg = '\nStart the Discovery Agent on a Windows machine';
+	const startTaLinuxMsg = '\nStart the Traceability Agent on a Linux based machine';
+	const startTaWinMsg = '\nStart the Traceability Agent on a Windows machine';
+
+	if (installConfig.switches.isDaEnabled && installConfig.switches.isTaEnabled) {
+		dockerInfo = `To utilize the agents, pull the latest Docker images and run them using the appropriate supplied environment files, (${helpers.configFiles.DA_ENV_VARS} & ${helpers.configFiles.TA_ENV_VARS}):`;
+	} else if (installConfig.switches.isDaEnabled) {
+		dockerInfo = `To utilize the discovery agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.DA_ENV_VARS}):`;
+	} else {
+		dockerInfo = `To utilize the traceability agent, pull the latest Docker image and run it using the supplied environment file, (${helpers.configFiles.TA_ENV_VARS}):`;
+	}
+	console.log(chalk.whiteBright(dockerInfo), '\n');
+
+	if (installConfig.switches.isDaEnabled) {
+		const daImageVersion = `${daImage}:${installConfig.daVersion}`;
+		console.log(chalk.white('Pull the latest image of the Discovery Agent:'));
+		console.log(chalk.cyan(`docker pull ${daImageVersion}`));
+		console.log(chalk.white(isWindows ? startDaWinMsg : startDaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runDaWinMsg : runDaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data ${daImageVersion}`), '\n');
+	}
+	if (installConfig.switches.isTaEnabled) {
+		const taImageVersion = `${taImage}:${installConfig.taVersion}`;
+		console.log(chalk.white('Pull the latest image of the Traceability Agent:'));
+		console.log(chalk.cyan(`docker pull ${taImageVersion}`));
+		console.log(chalk.white(isWindows ? startTaWinMsg : startTaLinuxMsg));
+		console.log(chalk.cyan(isWindows ? runTaWinMsg : runTaLinuxMsg));
+		console.log('\t', chalk.cyan(`-v /data -p 8888:8888 ${helpers.eolChar}`));
+		console.log('\t', chalk.cyan(`${taImageVersion}`), '\n');
+		console.log(chalk.white('Configure WSO2 to connect to localhost:8888.'));
+	}
+};
+
+async function askDiscoveryPrompts(agentValues: WSO2AgentValues) {
+	agentValues.wso2BaseURL = await askWSO2BaseURL();
+	agentValues.wso2ClientID = await askWSO2ClientID();
+	agentValues.wso2ClientSecret = await askWSO2ClientSecret();
+}
+
+export const completeInstall = async (installConfig: AgentInstallConfig): Promise<void> => {
+	/**
+	 * Create agent resources
+	 */
+	const agentValues = installConfig.gatewayConfig as WSO2AgentValues;
+
+	// Add final settings to WSO2 agentValues
+	agentValues.centralConfig = installConfig.centralConfig;
+	agentValues.traceabilityConfig = installConfig.traceabilityConfig;
+
+	console.log('Generating the configuration file(s)...');
+
+	if (installConfig.switches.isDaEnabled) {
+		writeTemplates(ConfigFiles.DAEnvVars, agentValues, wso2DAEnvVarTemplate);
+	}
+
+	if (installConfig.switches.isTaEnabled) {
+		writeTemplates(ConfigFiles.TAEnvVars, agentValues, wso2TAEnvVarTemplate);
+	}
+
+	console.log('Configuration file(s) have been successfully created.\n');
+
+	generateSuccessHelpMsg(installConfig);
 };
 
 export const WSO2InstallMethods: InstallationFlowMethods = {


### PR DESCRIPTION
Migrate and refactor the Engage CLI's INSTALL functionality for Agents (Both On-Prem and SaaS agents).

Please refer to the following classes:
src/commands/install/akamaiAgents.ts
src/commands/install/akamaiSaasAgents.ts
src/commands/install/backstageAgents.ts
src/commands/install/edgeAgents.ts
src/commands/install/gitHubSaasAgents.ts
src/commands/install/gitLabAgents.ts
src/commands/install/grayLogAgents.ts
src/commands/install/ibmAPIConnectAgents.ts
src/commands/install/istioAgents.ts
src/commands/install/kafkaAgents.ts
src/commands/install/sapApiPortalAgents.ts
src/commands/install/sensediaAgents.ts
src/commands/install/softwareAGWebMethodAgents.ts
src/commands/install/swaggerHubSaasAgents.ts
src/commands/install/traceableAgents.ts
src/commands/install/traceableSaasAgents.ts
src/commands/install/wso2Agents.ts
